### PR TITLE
Fix widgets being dropped from previewing the dirty settings from a snapshot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-customize-snapshots",
 	"description": "Allow Customizer states to be drafted, and previewed with a private URL.",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"type": "wordpress-plugin",
 	"homepage": "https://github.com/xwp/wp-customize-snapshots",
 	"license": "GPL-2.0+",

--- a/customize-snapshots.php
+++ b/customize-snapshots.php
@@ -3,7 +3,7 @@
  * Plugin Name: Customize Snapshots
  * Plugin URI: https://github.com/xwp/wp-customize-snapshots
  * Description: Allow Customizer states to be drafted, and previewed with a private URL.
- * Version: 0.2.1
+ * Version: 0.3.0
  * Author:  XWP
  * Author URI: https://xwp.co/
  * License: GPLv2+

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -127,7 +127,9 @@ class Customize_Snapshot_Manager {
 		 * filter \WP_Customize_Widgets::filter_option_sidebars_widgets_for_theme_switch()
 		 * which causes the sidebars_widgets to be overridden with a global variable.
 		 */
-		remove_action( 'wp_loaded', array( $this->customize_manager->widgets, 'override_sidebars_widgets_for_theme_switch' ) );
+		if ( ! is_admin() ) {
+			remove_action( 'wp_loaded', array( $this->customize_manager->widgets, 'override_sidebars_widgets_for_theme_switch' ) );
+		}
 	}
 
 	/**

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -530,7 +530,6 @@ class Customize_Snapshot_Manager {
 	 * Set the snapshot settings post value.
 	 */
 	public function set_post_values() {
-
 		if ( true === $this->snapshot->is_preview() ) {
 			$values = $this->snapshot->values();
 

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -498,7 +498,6 @@ class Customize_Snapshot_Manager {
 							</label>
 							<br>
 						<# } #>
-						<input type="submit" tabindex="-1" style="position:absolute; top:-5000px" />
 					</fieldset>
 				</form>
 			</div>

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -116,6 +116,18 @@ class Customize_Snapshot_Manager {
 		// Preview a Snapshot.
 		add_action( 'after_setup_theme', array( $this, 'set_post_values' ), 1 );
 		add_action( 'wp_loaded', array( $this, 'preview' ) );
+
+		/*
+		 * Disable routine which fails because \WP_Customize_Manager::setup_theme() is
+		 * never called in a frontend preview context, whereby the original_stylesheet
+		 * is never set and so \WP_Customize_Manager::is_theme_active() will thus
+		 * always return true because get_stylesheet() !== null.
+		 *
+		 * The action being removed is responsible for adding an option_sidebar_widgets
+		 * filter \WP_Customize_Widgets::filter_option_sidebars_widgets_for_theme_switch()
+		 * which causes the sidebars_widgets to be overridden with a global variable.
+		 */
+		remove_action( 'wp_loaded', array( $this->customize_manager->widgets, 'override_sidebars_widgets_for_theme_switch' ) );
 	}
 
 	/**

--- a/php/class-customize-snapshot.php
+++ b/php/class-customize-snapshot.php
@@ -140,7 +140,9 @@ class Customize_Snapshot {
 	 */
 	public function populate_customized_post_var() {
 		$_POST['customized'] = add_magic_quotes( wp_json_encode( $this->values() ) );
+		// @codingStandardsIgnoreStart
 		$_REQUEST['customized'] = $_POST['customized'];
+		// @codingStandardsIgnoreEnd
 	}
 
 	/**
@@ -221,12 +223,13 @@ class Customize_Snapshot {
 		}
 
 		add_action( 'pre_get_posts', array( $this, '_override_wp_query_is_single' ) );
-		$posts = get_posts( array(
+		$query = new \WP_Query( array(
 			'name' => $this->uuid,
 			'posts_per_page' => 1,
 			'post_type' => Customize_Snapshot_Manager::POST_TYPE,
 			'post_status' => array( 'draft', 'publish' ),
 		) );
+		$posts = $query->get_posts();
 		remove_action( 'pre_get_posts', array( $this, '_override_wp_query_is_single' ) );
 
 		if ( empty( $posts ) ) {
@@ -279,7 +282,7 @@ class Customize_Snapshot {
 
 		$value = $this->data[ $setting_id ];
 
-		// @todo if ( $setting ) { $setting->sanitize( wp_slash( $value ) ); } ?
+		// @todo is not empty, then return the unslashed sanitized value? e.g. if ( $setting ) { $value = $setting->sanitize( wp_slash( $value ) ); } ?
 		unset( $setting );
 
 		return $value;

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -25,7 +25,13 @@ class Plugin extends Plugin_Base {
 	public function __construct() {
 		parent::__construct();
 
-		$priority = 9; // Because WP_Customize_Widgets::register_settings() happens at after_setup_theme priority 10.
+		/*
+		 * Priority is 8 because \CustomizeWidgetsPlus\Widget_Posts::init() happens
+		 * at priority 9, and this calls \CustomizeWidgetsPlus\Widget_Posts::add_customize_hooks().
+		 * So we need priority 8 so that the Customizer will be initialized before Widget Posts
+		 * initializes.
+		 */
+		$priority = 8;
 		add_action( 'after_setup_theme', array( $this, 'init' ), $priority );
 	}
 

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -34,7 +34,7 @@ class Plugin extends Plugin_Base {
 	 *
 	 * @action after_setup_theme
 	 */
-	function init() {
+	public function init() {
 		add_action( 'wp_default_scripts', array( $this, 'register_scripts' ), 11 );
 		add_action( 'wp_default_styles', array( $this, 'register_styles' ), 11 );
 		add_action( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 10, 4 );
@@ -48,7 +48,7 @@ class Plugin extends Plugin_Base {
 	 * @param \WP_Scripts $wp_scripts Instance of \WP_Scripts.
 	 * @action wp_default_scripts
 	 */
-	function register_scripts( \WP_Scripts $wp_scripts ) {
+	public function register_scripts( \WP_Scripts $wp_scripts ) {
 		$min = ( SCRIPT_DEBUG ? '' : '.min' );
 		$src = $this->dir_url . 'js/customize-snapshots' . $min . '.js';
 		$deps = array( 'jquery', 'jquery-ui-dialog', 'wp-util', 'customize-widgets' );
@@ -61,7 +61,7 @@ class Plugin extends Plugin_Base {
 	 * @param \WP_Styles $wp_styles Instance of \WP_Styles.
 	 * @action wp_default_styles
 	 */
-	function register_styles( \WP_Styles $wp_styles ) {
+	public function register_styles( \WP_Styles $wp_styles ) {
 		$min = ( SCRIPT_DEBUG ? '' : '.min' );
 		$src = $this->dir_url . 'css/customize-snapshots' . $min . '.css';
 		$deps = array( 'wp-jquery-ui-dialog' );

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Allow Customizer states to be drafted, and previewed with a private URL.
 **Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize), [snapshots](https://wordpress.org/plugins/tags/snapshots)  
 **Requires at least:** 4.3  
 **Tested up to:** trunk  
-**Stable tag:** 0.2.1  
+**Stable tag:** 0.3.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customize-snapshots.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-snapshots) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-snapshots/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-snapshots) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-snapshots/dev-status.svg)](https://david-dm.org/xwp/wp-customize-snapshots#info=devDependencies) 
@@ -23,6 +23,12 @@ Requires PHP 5.3+.
 **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
 
 ## Changelog ##
+
+### 0.3.0 ###
+* Initialize Snapshots before Widget Posts so that `$wp_customize` will be set on the front-end.
+* Fix WordPress VIP PHPCS issues.
+* Update `dev-lib`.
+* Remove unused button markup in dialog.
 
 ### 0.2.1 ###
 * Fix AYS confirmation if the snapshot state is saved.

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Allow Customizer states to be drafted, and previewed with a private URL.
 **Stable tag:** 0.2.1  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
-[![Build Status](https://travis-ci.org/xwp/wp-customize-snapshots.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-snapshots) [![Build Status](https://coveralls.io/repos/xwp/wp-customize-snapshots/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-snapshots) [![devDependency Status](https://david-dm.org/xwp/wp-customize-snapshots/dev-status.svg)](https://david-dm.org/xwp/wp-customize-snapshots#info=devDependencies) 
+[![Build Status](https://travis-ci.org/xwp/wp-customize-snapshots.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-snapshots) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-snapshots/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-snapshots) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-snapshots/dev-status.svg)](https://david-dm.org/xwp/wp-customize-snapshots#info=devDependencies) 
 
 ## Description ##
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Allow Customizer states to be drafted, and previewed with a private URL.
 **Stable tag:** 0.2.1  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
-[![Build Status](https://travis-ci.org/xwp/wp-customize-snapshots.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-snapshots) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-snapshots/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-snapshots) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-snapshots/dev-status.svg)](https://david-dm.org/xwp/wp-customize-snapshots#info=devDependencies) 
+[![Build Status](https://travis-ci.org/xwp/wp-customize-snapshots.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-snapshots) [![Build Status](https://coveralls.io/repos/xwp/wp-customize-snapshots/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-snapshots) [![devDependency Status](https://david-dm.org/xwp/wp-customize-snapshots/dev-status.svg)](https://david-dm.org/xwp/wp-customize-snapshots#info=devDependencies) 
 
 ## Description ##
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: westonruter, valendesigns, xwp, newscorpau
 Requires at least: 4.3
 Tested up to: trunk
-Stable tag: 0.2.1
+Stable tag: 0.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: customizer, customize, snapshots
@@ -20,6 +20,12 @@ Requires PHP 5.3+.
 **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
 
 == Changelog ==
+
+= 0.3.0 =
+* Initialize Snapshots before Widget Posts so that `$wp_customize` will be set on the front-end.
+* Fix WordPress VIP PHPCS issues.
+* Update `dev-lib`.
+* Remove unused button markup in dialog.
 
 = 0.2.1 =
 * Fix AYS confirmation if the snapshot state is saved.

--- a/tests/php/test-class-plugin.php
+++ b/tests/php/test-class-plugin.php
@@ -9,9 +9,9 @@ class Test_Plugin extends \WP_UnitTestCase {
 	 */
 	function test_construct() {
 		$plugin = get_plugin_instance();
-		$this->assertEquals( 9, has_action( 'after_setup_theme', array( $plugin, 'init' ) ) );
+		$this->assertEquals( 8, has_action( 'after_setup_theme', array( $plugin, 'init' ) ) );
 	}
-	
+
 	/**
 	 * @see Plugin::init()
 	 */


### PR DESCRIPTION
In my testing, the change in e214e5a fixes the underlying problem for which #8 fixes the symptoms.

The reason for lowering the priority can be seen in [`CustomizeWidgetsPlus\Widget_Posts ::add_customize_hooks()`](https://github.com/xwp/wp-customize-widgets-plus/blob/1653d13beb950fe13a25b056aef1c344fe936fd7/php/class-widget-posts.php#L1189-L1192
add_customize_hooks):

``` php
global $wp_customize;
if ( empty( $wp_customize ) || $this->customize_hooks_added ) {
    return false;
}
```

With snapshots running _after_ Widget Posts, the `$wp_customize` variable would be empty and Widget Posts would then not initialize, and thus none of the widgets in posts would be available for the widget areas.
