### PR TITLE
Use window.location directly for obtaining customizeUrl

### DIFF
--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -175,7 +175,7 @@
 				regex = new RegExp( '([?&])customize_snapshot_uuid=.*?(&|$)', 'i' ),
 				separator = url.indexOf( '?' ) !== -1 ? '&' : '?',
 				header = $( '#customize-header-actions' ),
-				customizeUrl = api.previewer.targetWindow.get().location.toString(),
+				customizeUrl = window.location.href,
 				customizeSeparator = customizeUrl.indexOf( '?' ) !== -1 ? '&' : '?';
 
 			// Set the UUID.


### PR DESCRIPTION
The value stored in `api.previewer.targetWindow` is the `window` for the iframe and it gets destroyed when a refresh happens. I happened to try saving while a refresh was happening and I got an error raised because the value was not set. In any case, `window.location.href` is what we should be accessing anyway, I believe.
