### PR TITLE
Ensure that snapshot data is always an array

### DIFF
--- a/php/class-customize-snapshot.php
+++ b/php/class-customize-snapshot.php
@@ -109,8 +109,9 @@ class Customize_Snapshot {
 		if ( $post ) {
 			// For reason why base64 encoding is used, see Customize_Snapshot::save().
 			$this->data = json_decode( $post->post_content, true );
-			if ( json_last_error() ) {
-				$this->snapshot_manager->plugin->trigger_warning( 'JSON parse error: ' . ( function_exists( 'json_last_error_msg' ) ? json_last_error_msg() : json_last_error() ) );
+			if ( json_last_error() || ! is_array( $this->data ) ) {
+				$this->snapshot_manager->plugin->trigger_warning( 'JSON parse error, expected array: ' . ( function_exists( 'json_last_error_msg' ) ? json_last_error_msg() : json_last_error() ) );
+				$this->data = array();
 			}
 
 			if ( ! empty( $this->data ) ) {


### PR DESCRIPTION
Should fix these issues when data is corrupted:
- Warning: Invalid argument supplied for foreach() in .../customize-snapshots/php/class-customize-snapshot-manager.php on line 753
- Warning: Invalid argument supplied for foreach() in .../customize-snapshots/php/class-customize-snapshot.php on line 337
- Warning: Invalid argument supplied for foreach() in /var/www/html/wordpress/docroot/wp-includes/functions.php on line 3459
- Warning: array_filter() expects parameter 1 to be array, null given in .../customize-snapshots/php/class-customize-snapshot.php on line 314
- Warning: array_keys() expects parameter 1 to be array, null given in .../customize-snapshots/php/class-customize-snapshot.php on line 337
