### PR TITLE
Add frontend preview link when snapshot is saved

### DIFF
--- a/css/customize-snapshots.css
+++ b/css/customize-snapshots.css
@@ -1,3 +1,15 @@
+#snapshot-preview-link {
+	float: right;
+	margin-top: 13px;
+	margin-right: 4px;
+	color: #656a6f;
+}
+
+#snapshot-preview-link:hover,
+#snapshot-preview-link:focus,
+#snapshot-preview-link:active {
+	color: #191e23;
+}
 #snapshot-save {
 	float: right;
 	margin-top: 9px;

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -57,6 +57,8 @@
 				api.state( 'saved' ).set( false );
 				component.resetSavedStateQuietly();
 			}
+
+			api.trigger( 'snapshots-ready', component );
 		} );
 
 		api.bind( 'save', function( request ) {

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -32,7 +32,7 @@
 				return;
 			}
 			api.state.create( 'snapshot-saved', true );
-			api.state.create( 'snapshot-previewed', Boolean( component.data.isPreview ) );
+			api.state.create( 'snapshot-exists', Boolean( component.data.isPreview ) );
 			api.state.create( 'snapshot-submitted', true );
 			api.bind( 'change', function() {
 				api.state( 'snapshot-saved' ).set( false );
@@ -53,7 +53,7 @@
 				component.sendUpdateSnapshotRequest( { status: 'pending' } );
 			} );
 
-			if ( api.state( 'snapshot-previewed' ).get() ) {
+			if ( api.state( 'snapshot-exists' ).get() ) {
 				api.state( 'saved' ).set( false );
 				component.resetSavedStateQuietly();
 			}
@@ -76,7 +76,7 @@
 					if ( 0 === $( '#' + id ).length ) {
 						$( 'body' ).append( snapshotDialogPublishError( {
 							title: component.data.i18n.publish,
-							message: api.state( 'snapshot-previewed' ).get() ? component.data.i18n.permsMsg.update : component.data.i18n.permsMsg.save
+							message: api.state( 'snapshot-exists' ).get() ? component.data.i18n.permsMsg.update : component.data.i18n.permsMsg.save
 						} ) );
 					}
 
@@ -100,7 +100,7 @@
 
 			// Set the button text back to "Save".
 			component.changeButton( component.data.i18n.saveButton, component.data.i18n.permsMsg.save );
-			api.state( 'snapshot-previewed' ).set( false );
+			api.state( 'snapshot-exists' ).set( false );
 
 			request = wp.ajax.post( 'customize_get_snapshot_uuid', {
 				nonce: component.data.nonce,
@@ -141,7 +141,7 @@
 
 			retval = originalQuery.apply( this, arguments );
 
-			if ( api.state( 'snapshot-previewed' ).get() ) {
+			if ( api.state( 'snapshot-exists' ).get() ) {
 				api.each( function( value, key ) {
 					if ( value._dirty ) {
 						allCustomized[ key ] = {
@@ -185,11 +185,11 @@
 		// Save/update button.
 		snapshotButton = wp.template( 'snapshot-save' );
 		data = {
-			buttonText: api.state( 'snapshot-previewed' ).get() ? component.data.i18n.updateButton : component.data.i18n.saveButton
+			buttonText: api.state( 'snapshot-exists' ).get() ? component.data.i18n.updateButton : component.data.i18n.saveButton
 		};
 		snapshotButton = $( $.trim( snapshotButton( data ) ) );
 		if ( ! component.data.currentUserCanPublish ) {
-			snapshotButton.attr( 'title', api.state( 'snapshot-previewed' ).get() ? component.data.i18n.permsMsg.update : component.data.i18n.permsMsg.save );
+			snapshotButton.attr( 'title', api.state( 'snapshot-exists' ).get() ? component.data.i18n.permsMsg.update : component.data.i18n.permsMsg.save );
 		}
 		snapshotButton.prop( 'disabled', true );
 		snapshotButton.insertAfter( publishButton );
@@ -199,7 +199,7 @@
 		component.previewLink.toggle( api.state( 'snapshot-saved' ).get() );
 		component.previewLink.attr( 'target', component.data.uuid );
 		setPreviewLinkHref = _.debounce( function() {
-			if ( api.state( 'snapshot-previewed' ).get() ) {
+			if ( api.state( 'snapshot-exists' ).get() ) {
 				component.previewLink.attr( 'href', component.getSnapshotFrontendPreviewUrl() );
 			} else {
 				component.previewLink.attr( 'href', component.frontendPreviewUrl.get() );
@@ -302,7 +302,7 @@
 			snapshot_customized: JSON.stringify( customized ),
 			customize_snapshot_uuid: component.data.uuid,
 			status: args.status,
-			preview: ( api.state( 'snapshot-previewed' ).get() ? 'on' : 'off' )
+			preview: ( api.state( 'snapshot-exists' ).get() ? 'on' : 'off' )
 		} );
 
 		request.done( function( response ) {
@@ -326,7 +326,7 @@
 
 			// Change the save button text to update.
 			component.changeButton( component.data.i18n.updateButton, component.data.i18n.permsMsg.update );
-			api.state( 'snapshot-previewed' ).set( true );
+			api.state( 'snapshot-exists' ).set( true );
 
 			spinner.removeClass( 'is-active' );
 

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -835,6 +835,12 @@ class Customize_Snapshot_Manager {
 	 */
 	public function render_templates() {
 		?>
+		<script type="text/html" id="tmpl-snapshot-preview-link">
+			<a href="#" target="frontend-preview" id="snapshot-preview-link" class="dashicons dashicons-welcome-view-site" title="<?php esc_attr_e( 'View on frontend', 'customize-snapshots' ) ?>">
+				<span class="screen-reader-text"><?php esc_html_e( 'View on frontend', 'customize-snapshots' ) ?></span>
+			</a>
+		</script>
+
 		<script type="text/html" id="tmpl-snapshot-save">
 			<button id="snapshot-save" class="button button-secondary">
 				{{ data.buttonText }}


### PR DESCRIPTION
Initial state, preview icon links to previewUrl on the frontend without a snapshot UUUID:

![image](https://cloud.githubusercontent.com/assets/134745/16678776/29e4ed86-4497-11e6-9e35-8e823859e5ff.png)

Once a change is made, the preview link is hidden because the snapshot is not saved:

![image](https://cloud.githubusercontent.com/assets/134745/16678788/41b57e9e-4497-11e6-9a9e-3fb8e2081ec4.png)

Once the snapshot is saved, the preview link appears, this time with the URL including the `customize_snapshot_uuid`:

![image](https://cloud.githubusercontent.com/assets/134745/16678795/565bb6a6-4497-11e6-9770-b4ee3827a5ac.png)

Once published, the initial state is restored:

![image](https://cloud.githubusercontent.com/assets/134745/16678801/63f65eec-4497-11e6-8c5a-173b232820d2.png)

Note that plugins can override/rewrite the URL used that is used for the frontend preview link (such as pointing to another domain for a headless WP instance) by defining a `validate` method like so:

``` js
wp.customize.Snapshots.frontendPreviewUrl.validate = function( url ) {
    var urlParser = document.createElement( 'a' );
    urlParser.href = url;
    urlParser.hostname = 'some-other-frontend.example.com';
    return urlParser.href;
};
```
