### PR TITLE
Add initial read-only REST API endpoints for snapshots

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -1,3 +1,8 @@
 PATH_INCLUDES='*.* php js css tests'
 WPCS_GIT_TREE=develop
 ASSETS_DIR=wp-assets
+
+function after_wp_install {
+    echo "Installing REST API..."
+    svn export -q https://plugins.svn.wordpress.org/rest-api/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/rest-api"
+}

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -274,10 +274,13 @@ class Post_Type {
 				$actions
 			);
 
-			$frontend_view_url = add_query_arg( array_map( 'rawurlencode', $args ), home_url() );
 			$actions = array_merge(
 				array(
-					'front-view' => sprintf( '<a href="%s">%s</a>', esc_url( $frontend_view_url ), esc_html__( 'Preview Snapshot', 'customize-snapshots' ) ),
+					'front-view' => sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( get_permalink( $post->ID ) ),
+						esc_html__( 'Preview Snapshot', 'customize-snapshots' )
+					),
 				),
 				$actions
 			);

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -531,6 +531,12 @@ class Post_Type {
 			}
 			$post_arr['post_status'] = $args['status'];
 		}
+		if ( ! empty( $args['author'] ) ) {
+			$post_arr['post_author'] = $args['author'];
+		}
+		if ( ! empty( $args['date_gmt'] ) ) {
+			$post_arr['post_date_gmt'] = $args['date_gmt'];
+		}
 
 		$this->suspend_kses();
 		if ( $is_update ) {

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -94,7 +94,11 @@ class Post_Type {
 				'publish_posts' => 'do_not_allow',
 			),
 			'rewrite' => false,
-			'show_in_customizer' => false,
+			'show_in_customizer' => false, // Prevent inception.
+			'show_in_rest' => true,
+			'rest_base' => 'customize_snapshots',
+			'rest_controller_class' => __NAMESPACE__ . '\\Snapshot_REST_API_Controller',
+			'customize_snapshot_post_type_obj' => $this,
 			'menu_icon' => 'dashicons-camera',
 			'register_meta_box_cb' => array( $this, 'setup_metaboxes' ),
 		);

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -101,6 +101,7 @@ class Post_Type {
 
 		register_post_type( static::SLUG, $args );
 
+		add_filter( 'post_type_link', array( $this, 'filter_post_type_link' ), 10, 2 );
 		add_action( 'add_meta_boxes_' . static::SLUG, array( $this, 'remove_publish_metabox' ), 100 );
 		add_action( 'load-revision.php', array( $this, 'suspend_kses_for_snapshot_revision_restore' ) );
 		add_filter( 'bulk_actions-edit-' . static::SLUG, array( $this, 'filter_bulk_actions' ) );
@@ -108,6 +109,23 @@ class Post_Type {
 		add_filter( 'post_row_actions', array( $this, 'filter_post_row_actions' ), 10, 2 );
 		add_filter( 'wp_insert_post_data', array( $this, 'preserve_post_name_in_insert_data' ), 10, 2 );
 		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 10, 2 );
+	}
+
+	/**
+	 * Filter post link.
+	 *
+	 * @param string   $url  URL.
+	 * @param \WP_Post $post Post.
+	 * @return string URL.
+	 */
+	public function filter_post_type_link( $url, $post ) {
+		if ( self::SLUG === $post->post_type ) {
+			$url = add_query_arg(
+				array( 'customzie_snapshot_uuid' => $post->post_name ),
+				home_url( '/' )
+			);
+		}
+		return $url;
 	}
 
 	/**
@@ -329,7 +347,7 @@ class Post_Type {
 				esc_html__( 'Edit in Customizer', 'customize-snapshots' )
 			);
 
-			$frontend_view_url = add_query_arg( array_map( 'rawurlencode', $args ), home_url() );
+			$frontend_view_url = get_permalink( $post->ID );
 			echo sprintf(
 				'<a href="%s" class="button button-secondary">%s</a>',
 				esc_url( $frontend_view_url ),

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -121,7 +121,7 @@ class Post_Type {
 	public function filter_post_type_link( $url, $post ) {
 		if ( self::SLUG === $post->post_type ) {
 			$url = add_query_arg(
-				array( 'customzie_snapshot_uuid' => $post->post_name ),
+				array( 'customize_snapshot_uuid' => $post->post_name ),
 				home_url( '/' )
 			);
 		}

--- a/php/class-snapshot-rest-api-controller.php
+++ b/php/class-snapshot-rest-api-controller.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * REST API Controller.
+ *
+ * @package CustomizeSnapshots
+ */
+
+namespace CustomizeSnapshots;
+
+/**
+ * REST API Controller Class
+ *
+ * @todo Add support for editing.
+ * @todo Add support for PATCH requests.
+ * @todo Allow use of UUID instead of ID in routes.
+ * @todo Disallow edits to slug.
+ *
+ * @package CustomizeSnapshots
+ */
+class Snapshot_REST_API_Controller extends \WP_REST_Posts_Controller {
+
+	/**
+	 * Post type instance.
+	 *
+	 * @var Post_Type
+	 */
+	public $snapshot_post_type;
+
+	/**
+	 * Snapshot_REST_API_Controller constructor.
+	 *
+	 * @throws Exception If the post type was not registered properly.
+	 * @param string $post_type Post type.
+	 */
+	public function __construct( $post_type ) {
+		$post_type_obj = get_post_type_object( $post_type );
+		if ( empty( $post_type_obj ) || empty( $post_type_obj->customize_snapshot_post_type_obj ) ) {
+			throw new Exception( 'Missing customize_snapshot post type obj or arg for customize_snapshot_post_type_obj' );
+		}
+		$this->snapshot_post_type = $post_type_obj->customize_snapshot_post_type_obj;
+		parent::__construct( $post_type );
+	}
+
+	/**
+	 * Get the Post's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+		$schema['properties']['content'] = array(
+			'description' => __( 'Object mapping setting ID to an object of setting params, including value.', 'customize-snapshots' ),
+			'type'        => 'object',
+			'context'     => array( 'view', 'edit' ),
+		);
+		return $schema;
+	}
+
+	/**
+	 * Get the query params for collections of attachments.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$params['author']['sanitize_callback'] = array( $this, 'parse_author_list' );
+		$params['author_exclude']['sanitize_callback'] = array( $this, 'parse_author_list' );
+		return $params;
+	}
+
+	/**
+	 * Parse comma-separated list of authors represented as IDs or usernames.
+	 *
+	 * @param string $author_list Authors.
+	 * @return array User IDs.
+	 */
+	public function parse_author_list( $author_list ) {
+		if ( empty( $author_list ) ) {
+			return array();
+		}
+		$authors = array();
+		foreach ( preg_split( '/\s*,\s*/', trim( $author_list ) ) as $author ) {
+			if ( is_numeric( $author ) ) {
+				$authors[] = intval( $author );
+			} else {
+				$user = get_user_by( 'slug', sanitize_user( $author ) );
+				if ( $user ) {
+					$authors[] = $user->ID;
+				} else {
+					$authors[] = -1;
+				}
+			}
+		}
+		return $authors;
+	}
+
+	/**
+	 * Check for fundamental customize capability to do anything with snapshots.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	protected function check_initial_access_permission() {
+		if ( ! current_user_can( 'customize' ) ) {
+			return new \WP_Error( 'rest_customize_unauthorized', __( 'Sorry, Customizer snapshots require proper authentication.', 'customize-snapshots' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has basic access to read a snapshot.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		$error = $this->check_initial_access_permission();
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+		return parent::get_item_permissions_check( $request );
+	}
+
+	/**
+	 * Check if a given request has basic access to read snapshots.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		$error = $this->check_initial_access_permission();
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Restrict read permission to whether the user can edit.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return boolean Can we read it?
+	 */
+	public function check_read_permission( $post ) {
+		$post_type_obj = get_post_type_object( 'customize_snapshot' );
+		if ( ! current_user_can( $post_type_obj->cap->edit_post, $post->ID ) ) {
+			return false;
+		}
+		return current_user_can( 'customize' ) && parent::check_read_permission( $post );
+	}
+
+	/**
+	 * Prepare a single post output for response.
+	 *
+	 * @param \WP_Post         $post    Post object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response $response Response.
+	 */
+	public function prepare_item_for_response( $post, $request ) {
+		$response = parent::prepare_item_for_response( $post, $request );
+		$response->data['content'] = $this->snapshot_post_type->get_post_content( $post );
+		return $response;
+	}
+
+	/**
+	 * Prepare a single post for create or update.
+	 *
+	 * @todo This will be irrelevant when create_item and update_item are implemented, as they can use Post_Type::save() directly.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_Error|\stdClass $prepared_post Post object.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$prepared_post = parent::prepare_item_for_database( $request );
+		if ( ! is_wp_error( $prepared_post ) && is_array( $request['content'] ) ) {
+			$prepared_post->post_content = wp_json_encode( $request['content'] );
+		}
+		return $prepared_post;
+	}
+
+	/**
+	 * Create one item from the collection.
+	 *
+	 * @param \WP_REST_Request $request Full data about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		unset( $request );
+		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not yet implemented.", 'customize-snapshots' ), __METHOD__ ), array( 'status' => 405 ) );
+	}
+
+	/**
+	 * Update one item from the collection.
+	 *
+	 * @param \WP_REST_Request $request Full data about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		unset( $request );
+		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not yet implemented.", 'customize-snapshots' ), __METHOD__ ), array( 'status' => 405 ) );
+	}
+
+	/**
+	 * Delete one item from the collection.
+	 *
+	 * @param \WP_REST_Request $request Full data about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function delete_item( $request ) {
+		unset( $request );
+		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not yet implemented.", 'customize-snapshots' ), __METHOD__ ), array( 'status' => 405 ) );
+	}
+}

--- a/php/class-snapshot-rest-api-controller.php
+++ b/php/class-snapshot-rest-api-controller.php
@@ -10,7 +10,7 @@ namespace CustomizeSnapshots;
 /**
  * REST API Controller Class
  *
- * @todo Add support for editing.
+ * @todo Add support for editing. Make sure Post_Type::save() is used.
  * @todo Add support for PATCH requests.
  * @todo Allow use of UUID instead of ID in routes.
  * @todo Disallow edits to slug.
@@ -101,7 +101,7 @@ class Snapshot_REST_API_Controller extends \WP_REST_Posts_Controller {
 	 */
 	protected function check_initial_access_permission() {
 		if ( ! current_user_can( 'customize' ) ) {
-			return new \WP_Error( 'rest_customize_unauthorized', __( 'Sorry, Customizer snapshots require proper authentication.', 'customize-snapshots' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'rest_customize_unauthorized', __( 'Sorry, Customizer snapshots require proper authentication (the customize capability).', 'customize-snapshots' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -159,33 +159,6 @@ class Snapshot_REST_API_Controller extends \WP_REST_Posts_Controller {
 		$response = parent::prepare_item_for_response( $post, $request );
 		$response->data['content'] = $this->snapshot_post_type->get_post_content( $post );
 		return $response;
-	}
-
-	/**
-	 * Prepare a single post for create or update.
-	 *
-	 * @todo This will be irrelevant when create_item and update_item are implemented, as they can use Post_Type::save() directly.
-	 *
-	 * @param \WP_REST_Request $request Request object.
-	 * @return \WP_Error|\stdClass $prepared_post Post object.
-	 */
-	protected function prepare_item_for_database( $request ) {
-		$prepared_post = parent::prepare_item_for_database( $request );
-		if ( ! is_wp_error( $prepared_post ) && is_array( $request['content'] ) ) {
-			$prepared_post->post_content = wp_json_encode( $request['content'] );
-		}
-		return $prepared_post;
-	}
-
-	/**
-	 * Create one item from the collection.
-	 *
-	 * @param \WP_REST_Request $request Full data about the request.
-	 * @return \WP_Error|\WP_REST_Response
-	 */
-	public function create_item( $request ) {
-		unset( $request );
-		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not yet implemented.", 'customize-snapshots' ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,1 +1,31 @@
-dev-lib/phpunit-plugin.xml
+<phpunit
+	bootstrap="dev-lib/phpunit-plugin-bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TEST_VIP_QUICKSTART_ACTIVATED_PLUGINS" value="jetpack/jetpack.php,media-explorer/media-explorer.php,writing-helper/writing-helper.php,mrss/mrss.php,wordpress-importer/wordpress-importer.php,keyring/keyring.php,polldaddy/polldaddy.php" />
+		<const name="WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING" value="1" />
+		<const name="WP_TEST_ACTIVATED_PLUGINS" value="rest-api/plugin.php" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">./</directory>
+			<exclude>
+				<directory suffix=".php">./dev-lib</directory>
+				<directory suffix=".php">./node_modules</directory>
+				<directory suffix=".php">./tests</directory>
+				<directory suffix=".php">./vendor</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/tests/php/test-class-post-type.php
+++ b/tests/php/test-class-post-type.php
@@ -489,6 +489,25 @@ class Test_Post_type extends \WP_UnitTestCase {
 
 		$this->assertEquals( get_stylesheet(), get_post_meta( $r, '_snapshot_theme', true ) );
 		$this->assertEquals( $this->plugin->version, get_post_meta( $r, '_snapshot_version', true ) );
+
+		// Success with author supplied.
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		$post_id = $post_type->save( array(
+			'uuid' => self::UUID,
+			'data' => $data,
+			'status' => 'publish',
+			'author' => $user_id,
+		) );
+		$this->assertEquals( $user_id, get_post( $post_id )->post_author );
+
+		// Success with future date.
+		$post_id = $post_type->save( array(
+			'uuid' => self::UUID,
+			'data' => $data,
+			'status' => 'publish',
+			'date_gmt' => gmdate( 'Y-m-d H:i:s', time() + 24 * 3600 ),
+		) );
+		$this->assertEquals( 'future', get_post_status( $post_id ) );
 	}
 
 	/**

--- a/tests/php/test-class-post-type.php
+++ b/tests/php/test-class-post-type.php
@@ -46,6 +46,7 @@ class Test_Post_type extends \WP_UnitTestCase {
 		$post_type->register();
 		$this->assertTrue( post_type_exists( Post_Type::SLUG ) );
 
+		$this->assertEquals( 10, has_filter( 'post_type_link', array( $post_type, 'filter_post_type_link' ) ) );
 		$this->assertEquals( 100, has_action( 'add_meta_boxes_' . Post_Type::SLUG, array( $post_type, 'remove_publish_metabox' ) ) );
 		$this->assertEquals( 10, has_action( 'load-revision.php', array( $post_type, 'suspend_kses_for_snapshot_revision_restore' ) ) );
 		$this->assertEquals( 10, has_filter( 'bulk_actions-edit-' . Post_Type::SLUG, array( $post_type, 'filter_bulk_actions' ) ) );
@@ -55,7 +56,30 @@ class Test_Post_type extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'user_has_cap', array( $post_type, 'filter_user_has_cap' ) ) );
 	}
 
+	/**
+	 * Test filter_post_type_link.
+	 *
+	 * @covers Post_Type::filter_post_type_link()
+	 */
+	function test_filter_post_type_link() {
+		$post_type = new Post_Type( $this->plugin->customize_snapshot_manager );
 
+		$post_id = $post_type->save( array(
+			'uuid' => self::UUID,
+			'data' => array(
+				'blogname' => array( 'value' => 'Hello' ),
+			),
+		) );
+
+		$this->assertContains(
+			'customize_snapshot_uuid=' . self::UUID,
+			$post_type->filter_post_type_link( '', get_post( $post_id ) )
+		);
+
+		remove_all_filters( 'post_type_link' );
+		$post_type->register();
+		$this->assertContains( 'customize_snapshot_uuid=' . self::UUID, get_permalink( $post_id ) );
+	}
 
 	/**
 	 * Suspend kses which runs on content_save_pre and can corrupt JSON in post_content.

--- a/tests/php/test-class-snapshot-rest-api-controller.php
+++ b/tests/php/test-class-snapshot-rest-api-controller.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Test Post Type.
+ *
+ * @package CustomizeSnapshots
+ */
+
+namespace CustomizeSnapshots;
+
+/**
+ * Class Test_Post_type
+ */
+class Test_Snapshot_REST_API_Controller extends \WP_Test_REST_TestCase {
+
+	/**
+	 * Plugin.
+	 *
+	 * @var Plugin
+	 */
+	public $plugin;
+
+	/**
+	 * Server.
+	 *
+	 * @var \WP_REST_Server
+	 */
+	public $server;
+
+	/**
+	 * Snapshot post IDs s by status.
+	 *
+	 * @var array
+	 */
+	public $snapshot_by_status = array();
+
+	/**
+	 * Set up.
+	 */
+	function setUp() {
+		parent::setUp();
+		$this->plugin = get_plugin_instance();
+
+		$this->plugin->customize_snapshot_manager->post_type->register();
+
+		$snapshot_data = array(
+			array(
+				'status' => 'draft',
+				'date_gmt' => '2010-01-01 00:00:00',
+			),
+			array(
+				'status' => 'pending',
+				'date_gmt' => '2010-01-01 00:00:00',
+			),
+			array(
+				'status' => 'publish',
+				'date_gmt' => '2010-01-01 00:00:00',
+			),
+			array(
+				'status' => 'future',
+				'date_gmt' => gmdate( 'Y-m-d H:i:s', time() + 24 * 3600 ),
+			),
+		);
+		foreach ( $snapshot_data as $i => $snapshot_params ) {
+			$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+			$post_id = $this->plugin->customize_snapshot_manager->post_type->save( array_merge(
+				$snapshot_params,
+				array(
+					'uuid' => Customize_Snapshot_Manager::generate_uuid(),
+					'author' => $user_id,
+					'data' => array( 'blogname' => array( 'value' => "Snapshot $i" ) ),
+				)
+			) );
+			$this->snapshot_by_status[ $snapshot_params['status'] ] = $post_id;
+		}
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		$this->server = rest_get_server();
+	}
+
+	/**
+	 * Test unauthenticated requests for /wp/v2/customize_snapshots
+	 */
+	function test_get_collection_unauthenticated() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( current_user_can( 'customize' ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_customize_unauthorized', $response );
+	}
+
+	/**
+	 * Test unauthorized requests for /wp/v2/customize_snapshots
+	 */
+	function test_get_collection_unauthorized() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'contributor' ) ) );
+		$this->assertFalse( current_user_can( 'customize' ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_customize_unauthorized', $response );
+	}
+
+	/**
+	 * Test unauthorized requests for /wp/v2/customize_snapshots
+	 */
+	function test_get_collection_authorized() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertTrue( current_user_can( 'customize' ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test getting published items.
+	 */
+	function test_get_collection_published() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$items = $response->get_data();
+		$this->assertCount( 1, $items );
+		$this->assertEquals( 'publish', $items[0]['status'] );
+		$this->assertArrayHasKey( 'content', $items[0] );
+		$this->assertArrayHasKey( 'blogname', $items[0]['content'] );
+		$this->assertArrayHasKey( 'value', $items[0]['content']['blogname'] );
+
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$request->set_url_params( array( 'status' => 'publish' ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( $items, $response->get_data() );
+	}
+
+	/**
+	 * Test getting any items.
+	 */
+	function test_get_collection_any() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( 'status', 'any' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$items = $response->get_data();
+		$this->assertCount( 4, $items );
+		$item_statuses = wp_list_pluck( $items, 'status' );
+		$this->assertContains( 'draft', $item_statuses );
+		$this->assertContains( 'pending', $item_statuses );
+		$this->assertContains( 'publish', $item_statuses );
+		$this->assertContains( 'future', $item_statuses );
+	}
+
+	/**
+	 * Test getting items by author.
+	 */
+	function test_get_collection_by_author() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( 'status', 'any' );
+		$response = $this->server->dispatch( $request );
+		$items = $response->get_data();
+		$item_authors = array_values( wp_list_pluck( $items, 'author' ) );
+
+		$item_author_mapping = array();
+		foreach ( $items as $item ) {
+			$item_author_mapping[ $item['author'] ] = $item['slug'];
+		}
+
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( 'status', 'any' );
+		$request->set_param( 'author', $item_authors[0] );
+		$response = $this->server->dispatch( $request );
+		$items = $response->get_data();
+		$this->assertCount( 1, $items );
+		$this->assertEquals( $items[0]['slug'], $item_author_mapping[ $item_authors[0] ] );
+
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( 'status', 'any' );
+		$request->set_param( 'author', get_user_by( 'id', $item_authors[0] )->user_nicename );
+		$response = $this->server->dispatch( $request );
+		$items = $response->get_data();
+		$this->assertCount( 1, $items );
+		$this->assertEquals( $items[0]['slug'], $item_author_mapping[ $item_authors[0] ] );
+
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( 'status', 'any' );
+		$request->set_param( 'author', join( ',', $item_authors ) );
+		$response = $this->server->dispatch( $request );
+		$items = $response->get_data();
+		$this->assertCount( 4, $items );
+	}
+
+	/**
+	 * Test getting published items.
+	 */
+	function test_get_item_published() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$post = get_post( $this->snapshot_by_status['publish'] );
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/customize_snapshots/' . $post->ID );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$item = $response->get_data();
+		$this->assertArrayHasKey( 'content', $item );
+		$this->assertArrayHasKey( 'blogname', $item['content'] );
+		$this->assertArrayHasKey( 'value', $item['content']['blogname'] );
+		$this->assertEquals( 'publish', $item['status'] );
+	}
+
+	/**
+	 * Test create item.
+	 */
+	function test_create_item() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/customize_snapshots' );
+		$request->set_param( 'content', array( 'blogname' => array( 'value' => 'test' ) ) );
+		$request->set_param( 'slug', Customize_Snapshot_Manager::generate_uuid() );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_create', $response );
+	}
+
+	/**
+	 * Test update item.
+	 */
+	function test_update_item() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$post = get_post( $this->snapshot_by_status['publish'] );
+		$request = new \WP_REST_Request( 'PUT', '/wp/v2/customize_snapshots/' . $post->ID );
+		$request->set_param( 'content', array( 'blogname' => array( 'value' => 'test' ) ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'invalid-method', $response );
+	}
+
+	/**
+	 * Test update item.
+	 */
+	function test_delete_item() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$post = get_post( $this->snapshot_by_status['publish'] );
+		$request = new \WP_REST_Request( 'DELETE', '/wp/v2/customize_snapshots/' . $post->ID );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'invalid-method', $response );
+	}
+}


### PR DESCRIPTION
Examples:

Get all draft snapshots authored by user with username "jsmith":

```
http://src.wordpress-develop.dev/wp-json/wp/v2/customize_snapshots?status=draft&author=jsmith
```

Get a snapshot by a UUID:

```
http://src.wordpress-develop.dev/wp-json/wp/v2/customize_snapshots?status=any&slug=fcc0a3f0-2d6d-4e4b-906b-46025857b07a
```

An individual item will look like the following (take note of `content`):

``` json
{
  "id": 6030,
  "date": "2016-07-23T06:11:22",
  "date_gmt": null,
  "guid": {
    "rendered": "http://src.wordpress-develop.dev/?customize_snapshot_uuid=fcc0a3f0-2d6d-4e4b-906b-46025857b07a"
  },
  "modified": "2016-07-23T06:11:22",
  "modified_gmt": null,
  "slug": "fcc0a3f0-2d6d-4e4b-906b-46025857b07a",
  "type": "customize_snapshot",
  "link": "http://src.wordpress-develop.dev/?customize_snapshot_uuid=fcc0a3f0-2d6d-4e4b-906b-46025857b07a",
  "content": {
    "blogname": {
      "value": "WordPress Coool"
    }
  },
  "author": 4,
  "_links": {
    "self": [
      {
        "href": "http://src.wordpress-develop.dev/wp-json/wp/v2/customize_snapshots/6030"
      }
    ],
    "collection": [
      {
        "href": "http://src.wordpress-develop.dev/wp-json/wp/v2/customize_snapshots"
      }
    ],
    "about": [
      {
        "href": "http://src.wordpress-develop.dev/wp-json/wp/v2/types/customize_snapshot"
      }
    ],
    "author": [
      {
        "embeddable": true,
        "href": "http://src.wordpress-develop.dev/wp-json/wp/v2/users/4"
      }
    ],
    "version-history": [
      {
        "href": "http://src.wordpress-develop.dev/wp-json/wp/v2/customize_snapshots/6030/revisions"
      }
    ],
    "wp:attachment": [
      {
        "href": "http://src.wordpress-develop.dev/wp-json/wp/v2/media?parent=6030"
      }
    ],
    "curies": [
      {
        "name": "wp",
        "href": "https://api.w.org/{rel}",
        "templated": true
      }
    ]
  }
}
```

Fixes #29.
