### PR TITLE
Ensure frontend links and Ajax requests include UUID query param; add previewing of Ajax requests and form submissions

### DIFF
--- a/css/customize-snapshots-preview.css
+++ b/css/customize-snapshots-preview.css
@@ -1,0 +1,8 @@
+form[method="post"] button[type="submit"],
+form[method="post"] button[type=""],
+form[method="post"] input[type="submit"] {
+	cursor: not-allowed;
+}
+form[method="post"] button:not([type]) {
+	cursor: not-allowed;
+}

--- a/customize-snapshots.php
+++ b/customize-snapshots.php
@@ -44,7 +44,7 @@ if ( version_compare( phpversion(), '5.3', '>=' ) ) {
  * Admin notice for incompatible versions of PHP.
  */
 function customize_snapshots_php_version_error() {
-	printf( '<div class="error"><p>%s</p></div>', customize_snapshots_php_version_text() );
+	printf( '<div class="error"><p>%s</p></div>', customize_snapshots_php_version_text() ); // WPCS: XSS OK.
 }
 
 /**

--- a/instance.php
+++ b/instance.php
@@ -23,3 +23,31 @@ function get_plugin_instance() {
 	global $customize_snapshots_plugin;
 	return $customize_snapshots_plugin;
 }
+
+/**
+ * Convenience function for whether settings are being previewed.
+ *
+ * @see Customize_Snapshot_Manager::is_previewing_settings()
+ * @see Customize_Snapshot_Manager::preview_snapshot_settings()
+ *
+ * @return bool Whether previewing settings.
+ */
+function is_previewing_settings() {
+	return get_plugin_instance()->customize_snapshot_manager->is_previewing_settings();
+}
+
+/**
+ * Convenience function to get the current snapshot UUID.
+ *
+ * @see Customize_Snapshot_Manager::$current_snapshot_uuid
+ *
+ * @return string|null The current snapshot UUID or null if no snapshot.
+ */
+function current_snapshot_uuid() {
+	$customize_snapshot_uuid = get_plugin_instance()->customize_snapshot_manager->current_snapshot_uuid;
+	if ( empty( $customize_snapshot_uuid ) ) {
+		return null;
+	} else {
+		return $customize_snapshot_uuid;
+	}
+}

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -18,7 +18,8 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 				path: ''
 			},
 			l10n: {
-				restoreSessionPrompt: ''
+				restoreSessionPrompt: '',
+				leaveSessionPrompt: ''
 			}
 		}
 	};
@@ -33,6 +34,8 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	component.init = function init( args ) {
 		_.extend( component.data, args );
 
+		component.hasSessionStorage = 'undefined' !== typeof sessionStorage;
+
 		component.keepSessionAlive();
 		component.rememberSessionSnapshot();
 		component.injectSnapshotIntoLinks();
@@ -45,7 +48,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 */
 	component.keepSessionAlive = function keepSessionAlive() {
 		var currentSnapshotUuid, urlParser;
-		if ( 'undefined' === typeof sessionStorage ) {
+		if ( ! component.hasSessionStorage ) {
 			return;
 		}
 		currentSnapshotUuid = sessionStorage.getItem( 'customize_snapshot_uuid' );
@@ -73,7 +76,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @returns {void}
 	 */
 	component.rememberSessionSnapshot = function rememberSessionSnapshot() {
-		if ( 'undefined' === typeof sessionStorage || ! component.data.uuid ) {
+		if ( ! component.hasSessionStorage || ! component.data.uuid ) {
 			return;
 		}
 		sessionStorage.setItem( 'customize_snapshot_uuid', component.data.uuid );
@@ -88,9 +91,62 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		if ( ! component.data.uuid ) {
 			return;
 		}
-		$( document.documentElement ).on( 'click focus mouseover', 'a, area', function() {
+		$( document.documentElement ).on( 'click focus mouseover', 'a, area', function( event ) {
 			component.injectLinkQueryParam( this );
+
+			if ( 'click' === event.type && ! component.isLinkSnapshottable( this ) ) {
+				if ( confirm( component.data.l10n.leaveSessionPrompt ) ) {
+					if ( component.hasSessionStorage ) {
+						sessionStorage.removeItem( 'customize_snapshot_uuid' );
+					}
+				} else {
+					event.preventDefault();
+				}
+			}
 		} );
+	};
+
+	/**
+	 * Should the supplied link have a snapshot UUID added (or does it have one already)?
+	 *
+	 * @param {HTMLAnchorElement|HTMLAreaElement} element Link element.
+	 * @param {string} element.search Query string.
+	 * @param {string} element.pathname Path.
+	 * @param {string} element.hostname Hostname.
+	 * @returns {boolean} Is appropriate for snapshot link.
+	 */
+	component.isLinkSnapshottable = function isLinkSnapshottable( element ) {
+		if ( element.hostname !== component.data.home_url.host ) {
+			return false;
+		}
+		if ( 0 !== element.pathname.indexOf( component.data.home_url.path ) ) {
+			return false;
+		}
+
+		if ( /\/wp-(login|signup)\.php$/.test( element.pathname ) ) {
+			return false;
+		}
+
+		// @todo The snapshot UUID is getting added here still.
+		if ( $( element ).parent().is( '#wp-admin-bar-snapshot-view-link' ) ) {
+			return true;
+		}
+
+		if ( /(^|&)customize_snapshot_uuid=/.test( element.search.substr( 1 ) ) ) {
+			return true;
+		}
+
+		// Allow links to admin ajax as faux frontend URLs.
+		if ( /\/wp-admin\/admin-ajax\.php$/.test( element.pathname ) ) {
+			return true;
+		}
+
+		// Disallow links to admin.
+		if ( /\/wp-admin(\/|$)/.test( element.pathname ) ) {
+			return false;
+		}
+
+		return true;
 	};
 
 	/**
@@ -101,10 +157,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @returns {void}
 	 */
 	component.injectLinkQueryParam = function injectLinkQueryParam( element ) {
-		if ( element.hostname !== component.data.home_url.host ) {
-			return;
-		}
-		if ( 0 !== element.pathname.indexOf( component.data.home_url.path ) ) {
+		if ( ! component.isLinkSnapshottable( element ) ) {
 			return;
 		}
 		if ( /(^|&)customize_snapshot_uuid=/.test( element.search.substr( 1 ) ) ) {

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -3,6 +3,11 @@
 /* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [-1,0,1] } ] */
 /* eslint-disable no-alert */
 
+/*
+ * The code here is derived from the initial Transactions pull request: https://github.com/xwp/wordpress-develop/pull/61
+ * See https://github.com/xwp/wordpress-develop/blob/97fd5019c488a0713d34b517bdbff67c62c48a5d/src/wp-includes/js/customize-preview.js#L98-L111
+ */
+
 var CustomizeSnapshotsFrontend = ( function( $ ) {
 	'use strict';
 

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -15,8 +15,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 				path: ''
 			},
 			l10n: {
-				restoreSessionPrompt: '',
-				leaveSessionPrompt: ''
+				restoreSessionPrompt: ''
 			}
 		}
 	};

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -42,6 +42,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		component.injectSnapshotIntoLinks();
 		component.handleExitSnapshotSessionLink();
 		component.injectSnapshotIntoAjaxRequests();
+		component.injectSnapshotIntoForms();
 	};
 
 	/**
@@ -108,7 +109,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 
 			// Inject links into initial document.
 			$( document.body ).find( linkSelectors ).each( function() {
-				component.injectLinkQueryParam( this );
+				component.injectSnapshotLinkParam( this );
 			} );
 
 			// Inject links for new elements added to the page
@@ -116,7 +117,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 				component.mutationObserver = new MutationObserver( function( mutations ) {
 					_.each( mutations, function( mutation ) {
 						$( mutation.target ).find( linkSelectors ).each( function() {
-							component.injectLinkQueryParam( this );
+							component.injectSnapshotLinkParam( this );
 						} );
 					} );
 				} );
@@ -128,7 +129,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 
 				// If mutation observers aren't available, fallback to just-in-time injection.
 				$( document.documentElement ).on( 'click focus mouseover', linkSelectors, function() {
-					component.injectLinkQueryParam( this );
+					component.injectSnapshotLinkParam( this );
 				} );
 			}
 		} );
@@ -201,7 +202,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @param {object} element.search Query string.
 	 * @returns {void}
 	 */
-	component.injectLinkQueryParam = function injectLinkQueryParam( element ) {
+	component.injectSnapshotLinkParam = function injectSnapshotLinkParam( element ) {
 		if ( component.doesLinkHaveSnapshotQueryParam( element ) || ! component.shouldLinkHaveSnapshotParam( element ) ) {
 			return;
 		}
@@ -270,6 +271,63 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		urlParser.search += 'customize_snapshot_uuid=' + component.data.uuid;
 
 		options.url = urlParser.href;
+	};
+
+	/**
+	 * Inject snapshot into forms, allowing preview to persist through submissions.
+	 *
+	 * @returns {void}
+	 */
+	component.injectSnapshotIntoForms = function injectSnapshotIntoForms() {
+		if ( ! component.data.uuid ) {
+			return;
+		}
+		$( function() {
+
+			// Inject inputs for forms in initial document.
+			$( document.body ).find( 'form' ).each( function() {
+				component.injectSnapshotFormInput( this );
+			} );
+
+			// Inject inputs for new forms added to the page.
+			if ( 'undefined' !== typeof MutationObserver ) {
+				component.mutationObserver = new MutationObserver( function( mutations ) {
+					_.each( mutations, function( mutation ) {
+						$( mutation.target ).find( 'form' ).each( function() {
+							component.injectSnapshotFormInput( this );
+						} );
+					} );
+				} );
+				component.mutationObserver.observe( document.documentElement, {
+					childList: true,
+					subtree: true
+				} );
+			}
+		} );
+	};
+
+	/**
+	 * Inject snapshot into form inputs.
+	 *
+	 * @param {HTMLFormElement} form Form.
+	 * @returns {void}
+	 */
+	component.injectSnapshotFormInput = function injectSnapshotFormInput( form ) {
+		var urlParser;
+		if ( form.querySelector( 'input[name=customize_snapshot_uuid]' ) ) {
+			return;
+		}
+		urlParser = document.createElement( 'a' );
+		urlParser.href = form.action;
+		if ( ! component.isMatchingBaseUrl( urlParser ) ) {
+			return;
+		}
+
+		$( form ).prepend( $( '<input>', {
+			type: 'hidden',
+			name: 'customize_snapshot_uuid',
+			value: component.data.uuid
+		} ) );
 	};
 
 	return component;

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -101,16 +101,6 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		}
 		$( document.documentElement ).on( 'click focus mouseover', 'a, area', function( event ) {
 			component.injectLinkQueryParam( this );
-
-			if ( 'click' === event.type && ! component.doesLinkHaveSnapshotQueryParam( this ) && ! $( this ).parent().hasClass( 'ab-customize-snapshots-item' ) ) {
-				if ( confirm( component.data.l10n.leaveSessionPrompt ) ) {
-					if ( component.hasSessionStorage ) {
-						sessionStorage.removeItem( 'customize_snapshot_uuid' );
-					}
-				} else {
-					event.preventDefault();
-				}
-			}
 		} );
 	};
 

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -47,7 +47,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @returns {void}
 	 */
 	component.keepSessionAlive = function keepSessionAlive() {
-		var currentSnapshotUuid, urlParser;
+		var currentSnapshotUuid, urlParser, adminBarItem;
 		if ( ! component.hasSessionStorage ) {
 			return;
 		}
@@ -55,17 +55,25 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		if ( ! currentSnapshotUuid || component.data.uuid ) {
 			return;
 		}
-		if ( confirm( component.data.l10n.restoreSessionPrompt ) ) {
-			urlParser = document.createElement( 'a' );
-			urlParser.href = location.href;
-			if ( urlParser.search.length > 1 ) {
-				urlParser.search += '&';
-			}
-			urlParser.search += 'customize_snapshot_uuid=' + encodeURIComponent( sessionStorage.getItem( 'customize_snapshot_uuid' ) );
-			location.replace( urlParser.href );
-		} else {
-			sessionStorage.removeItem( 'customize_snapshot_uuid' );
+
+		urlParser = document.createElement( 'a' );
+		urlParser.href = location.href;
+		if ( urlParser.search.length > 1 ) {
+			urlParser.search += '&';
 		}
+		urlParser.search += 'customize_snapshot_uuid=' + encodeURIComponent( sessionStorage.getItem( 'customize_snapshot_uuid' ) );
+
+		$( function() {
+			adminBarItem = $( '#wp-admin-bar-resume-customize-snapshot' );
+			if ( adminBarItem.length ) {
+				adminBarItem.find( '> a' ).prop( 'href', urlParser.href );
+				adminBarItem.show();
+			} else if ( confirm( component.data.l10n.restoreSessionPrompt ) ) {
+				location.replace( urlParser.href );
+			} else {
+				sessionStorage.removeItem( 'customize_snapshot_uuid' );
+			}
+		} );
 	};
 
 	/**

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -1,0 +1,68 @@
+/* global jQuery */
+/* exported CustomizeSnapshotsFrontend */
+/* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [0,1] } ] */
+
+// @todo Use session storage to make sure the user stays in the snapshot frontend preview, unless explicitly exited. Warn with confirm if clicking.
+// @todo Inject customize_snapshot_uuid into all Ajax requests back to the site.
+
+var CustomizeSnapshotsFrontend = ( function( $ ) {
+	'use strict';
+
+	var component = {
+		data: {
+			uuid: '',
+			home_url: {
+				scheme: '',
+				host: '',
+				path: ''
+			}
+		}
+	};
+
+	/**
+	 * Init.
+	 *
+	 * @param {object} args Args.
+	 * @param {string} args.uuid UUID.
+	 * @returns {void}
+	 */
+	component.init = function init( args ) {
+		if ( ! args.uuid ) {
+			throw new Error( 'Missing UUID' );
+		}
+
+		_.extend( component.data, args );
+
+		// Inject snapshot UUID into links on click.
+		$( document.documentElement ).on( 'click focus mouseover', 'a, area', function() {
+			component.injectQueryParam( this );
+		} );
+	};
+
+	/**
+	 * Inject the customize_snapshot_uuid query param into links on the frontend.
+	 *
+	 * @param {HTMLAnchorElement|HTMLAreaElement} element Link element.
+	 * @param {object} element.search Query string.
+	 * @returns {void}
+	 */
+	component.injectQueryParam = function injectQueryParam( element ) {
+		if ( element.hostname !== component.data.home_url.host ) {
+			return;
+		}
+		if ( 0 !== element.pathname.indexOf( component.data.home_url.path ) ) {
+			return;
+		}
+		if ( /(^|&)customize_snapshot_uuid=/.test( element.search.substr( 1 ) ) ) {
+			return;
+		}
+
+		if ( element.search.length > 1 ) {
+			element.search += '&';
+		}
+		element.search += 'customize_snapshot_uuid=' + encodeURIComponent( component.data.uuid );
+	};
+
+	return component;
+} )( jQuery );
+

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -96,11 +96,38 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @returns {void}
 	 */
 	component.injectSnapshotIntoLinks = function injectSnapshotIntoLinks() {
+		var linkSelectors = 'a, area';
+
 		if ( ! component.data.uuid ) {
 			return;
 		}
-		$( document.documentElement ).on( 'click focus mouseover', 'a, area', function( event ) {
-			component.injectLinkQueryParam( this );
+		$( function() {
+
+			// Inject links into initial document.
+			$( document.body ).find( linkSelectors ).each( function() {
+				component.injectLinkQueryParam( this );
+			} );
+
+			// Inject links for new elements added to the page
+			if ( 'undefined' !== typeof MutationObserver ) {
+				component.mutationObserver = new MutationObserver( function( mutations ) {
+					_.each( mutations, function( mutation ) {
+						$( mutation.target ).find( linkSelectors ).each( function() {
+							component.injectLinkQueryParam( this );
+						} );
+					} );
+				} );
+				component.mutationObserver.observe( document.documentElement, {
+					childList: true,
+					subtree: true
+				} );
+			} else {
+
+				// If mutation observers aren't available, fallback to just-in-time injection.
+				$( document.documentElement ).on( 'click focus mouseover', linkSelectors, function() {
+					component.injectLinkQueryParam( this );
+				} );
+			}
 		} );
 	};
 

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -314,7 +314,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 */
 	component.injectSnapshotFormInput = function injectSnapshotFormInput( form ) {
 		var urlParser;
-		if ( form.querySelector( 'input[name=customize_snapshot_uuid]' ) ) {
+		if ( $( form ).find( 'input[name=customize_snapshot_uuid]' ).length > 0 ) {
 			return;
 		}
 		urlParser = document.createElement( 'a' );

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -1,1 +1,132 @@
+/* global jQuery, JSON */
+/* exported CustomizeSnapshotsPreview */
+/* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [-1,0,1] } ] */
+/* eslint-disable no-alert */
+
 // @todo Inject customized state into all Ajax requests back to the site? All can be taken from Customize REST Resources.
+
+var CustomizeSnapshotsPreview = (function( api, $ ) {
+	'use strict';
+
+	var component = {
+		data: {
+			home_url: {
+				scheme: '',
+				host: '',
+				path: ''
+			},
+			initial_dirty_settings: []
+		}
+	};
+
+	/**
+	 * Init.
+	 *
+	 * @param {object} args Args.
+	 * @param {string} args.uuid UUID.
+	 * @returns {void}
+	 */
+	component.init = function init( args ) {
+		_.extend( component.data, args );
+
+		component.injectSnapshotIntoAjaxRequests();
+	};
+
+	/**
+	 * Get customize query vars.
+	 *
+	 * @see wp.customize.previewer.query
+	 *
+	 * @returns {{
+	 *     customized: string,
+	 *     nonce: string,
+	 *     wp_customize: string,
+	 *     theme: string
+	 * }} Query vars.
+	 */
+	component.getCustomizeQueryVars = function getCustomizeQueryVars() {
+		var customized = {};
+		api.each( function( setting ) {
+			if ( setting._dirty || -1 !== _.indexOf( component.data.initial_dirty_settings, setting.id ) ) {
+				customized[ setting.id ] = setting.get();
+			}
+		} );
+		return {
+			wp_customize: 'on',
+			theme: api.settings.theme.stylesheet,
+			nonce: api.settings.nonce.preview,
+			customized: JSON.stringify( customized )
+		};
+	};
+
+	/**
+	 * Inject the snapshot UUID into Ajax requests.
+	 *
+	 * @return {void}
+	 */
+	component.injectSnapshotIntoAjaxRequests = function injectSnapshotIntoAjaxRequests() {
+		$.ajaxPrefilter( component.prefilterAjax );
+	};
+
+	/**
+	 * Rewrite Ajax requests to inject Customizer state.
+	 *
+	 * This will not work 100% of the time, such as if an Admin Ajax handler is
+	 * specifically looking for a $_GET param vs a $_POST param.
+	 * @todo We could rewrite the REQUEST_METHOD and $_POST to $_GET when wp_customize_preview_ajax.
+	 *
+	 * @param {object} options Options.
+	 * @param {string} options.type Type.
+	 * @param {string} options.url URL.
+	 * @param {object} originalOptions Original options.
+	 * @param {XMLHttpRequest} xhr XHR.
+	 * @returns {void}
+	 */
+	component.prefilterAjax = function prefilterAjax( options, originalOptions, xhr ) {
+		var requestMethod, urlParser, queryVars;
+
+		urlParser = document.createElement( 'a' );
+		urlParser.href = options.url;
+
+		// @todo Handle admin_ajax and rest_api requests differently?
+		if ( urlParser.host !== component.data.home_url.host || 0 !== urlParser.pathname.indexOf( component.data.home_url.path ) ) {
+			return;
+		}
+
+		requestMethod = options.type.toUpperCase();
+
+		// Customizer currently requires POST requests, so use override (force Backbone.emulateHTTP).
+		if ( 'POST' !== requestMethod ) {
+			xhr.setRequestHeader( 'X-HTTP-Method-Override', requestMethod );
+			options.type = 'POST';
+		}
+
+		if ( options.data && 'GET' === requestMethod ) {
+			/*
+			 * Make sure the query vars for the REST API persist in GET (since
+			 * REST API explicitly look at $_GET['filter']).
+			 * We have to make sure the REST query vars are added as GET params
+			 * when the method is GET as otherwise they won't be parsed properly.
+			 * The issue lies in \WP_REST_Request::get_parameter_order() which
+			 * only is looking at \WP_REST_Request::$method instead of $_SERVER['REQUEST_METHOD'].
+			 * @todo Improve \WP_REST_Request::get_parameter_order() to be more aware of X-HTTP-Method-Override
+			 */
+			if ( urlParser.search.substr( 1 ).length > 1 ) {
+				urlParser.search += '&';
+			}
+			urlParser.search += options.data;
+		}
+
+		// Add Customizer post data.
+		if ( options.data ) {
+			options.data += '&';
+		} else {
+			options.data = '';
+		}
+		queryVars = component.getCustomizeQueryVars();
+		queryVars.wp_customize_preview_ajax = 'true';
+		options.data += jQuery.param( queryVars );
+	};
+
+	return component;
+} )( wp.customize, jQuery );

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -158,23 +158,9 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	};
 
 	/**
-	 * Check if form is previewable (has a GET method and an action pointing to WP).
-	 *
-	 * @param {HTMLFormElement} form Form.
-	 * @returns {boolean} Is previewable.
-	 */
-	component.isFormPreviewable = function isFormPreviewable( form ) {
-		var method = form.method.toUpperCase(), urlParser;
-		if ( 'GET' !== method ) {
-			return false;
-		}
-		urlParser = document.createElement( 'a' );
-		urlParser.href = form.action;
-		return urlParser.host === component.data.home_url.host && 0 === urlParser.pathname.indexOf( component.data.home_url.path );
-	};
-
-	/**
 	 * Replace form submit handler.
+	 *
+	 * @returns {void}
 	 */
 	component.replaceFormSubmitHandler = function replaceFormSubmitHandler() {
 		var body = $( document.body );
@@ -190,7 +176,7 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 			 * URL and send this in a url message to the Customizer pane so that
 			 * it will be loaded.
 			 */
-			if ( ! event.isDefaultPrevented() && component.isFormPreviewable( this ) ) {
+			if ( ! event.isDefaultPrevented() && 'GET' === this.method.toUpperCase() ) {
 				urlParser = document.createElement( 'a' );
 				urlParser.href = this.action;
 				if ( urlParser.search.substr( 1 ).length > 1 ) {

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -41,6 +41,7 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 		_.extend( component.data, args );
 
 		component.injectSnapshotIntoAjaxRequests();
+		component.handleFormSubmissions();
 	};
 
 	/**
@@ -139,6 +140,70 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 		queryVars = component.getCustomizeQueryVars();
 		queryVars.wp_customize_preview_ajax = 'true';
 		options.data += $.param( queryVars );
+	};
+
+	/**
+	 * Handle form submissions.
+	 *
+	 * Implements todo in https://github.com/xwp/wordpress-develop/blob/4.5.3/src/wp-includes/js/customize-preview.js#L69-L73
+	 */
+	component.handleFormSubmissions = function handleFormSubmissions() {
+		$( function() {
+
+			// Defer so that we can be sure that our event handler will come after any other event handlers.
+			_.defer( function() {
+				component.replaceFormSubmitHandler();
+			} );
+		} );
+	};
+
+	/**
+	 * Check if form is previewable (has a GET method and an action pointing to WP).
+	 *
+	 * @param {HTMLFormElement} form Form.
+	 * @returns {boolean} Is previewable.
+	 */
+	component.isFormPreviewable = function isFormPreviewable( form ) {
+		var method = form.method.toUpperCase(), urlParser;
+		if ( 'GET' !== method ) {
+			return false;
+		}
+		urlParser = document.createElement( 'a' );
+		urlParser.href = form.action;
+		return urlParser.host === component.data.home_url.host && 0 === urlParser.pathname.indexOf( component.data.home_url.path );
+	};
+
+	/**
+	 * Replace form submit handler.
+	 */
+	component.replaceFormSubmitHandler = function replaceFormSubmitHandler() {
+		var body = $( document.body );
+		body.off( 'submit.preview' );
+		body.on( 'submit.preview', 'form', function( event ) {
+			var urlParser;
+
+			/*
+			 * If the default wasn't prevented already (in which case the form
+			 * submission is already being handled by JS), and if the method is
+			 * GET and its action points to a URL on this site, then take the
+			 * serialized form data and add it as a query string to the action
+			 * URL and send this in a url message to the Customizer pane so that
+			 * it will be loaded.
+			 */
+			if ( ! event.isDefaultPrevented() && component.isFormPreviewable( this ) ) {
+				urlParser = document.createElement( 'a' );
+				urlParser.href = this.action;
+				if ( urlParser.search.substr( 1 ).length > 1 ) {
+					urlParser.search += '&';
+				}
+				urlParser.search += $( this ).serialize();
+
+				api.preview.send( 'url', urlParser.href );
+			}
+
+			// Now preventDefault as is done on the normal submit.preview handler in customize-preview.js.
+			event.preventDefault();
+		});
 	};
 
 	return component;

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -1,9 +1,10 @@
 /* global jQuery, JSON */
 /* exported CustomizeSnapshotsPreview */
 /* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [-1,0,1] } ] */
-/* eslint-disable no-alert */
 
-// @todo Inject customized state into all Ajax requests back to the site? All can be taken from Customize REST Resources.
+/*
+ * The code here is derived from Customize REST Resources: https://github.com/xwp/wp-customize-rest-resources
+ */
 
 var CustomizeSnapshotsPreview = (function( api, $ ) {
 	'use strict';
@@ -11,6 +12,16 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	var component = {
 		data: {
 			home_url: {
+				scheme: '',
+				host: '',
+				path: ''
+			},
+			rest_api_url: {
+				scheme: '',
+				host: '',
+				path: ''
+			},
+			admin_ajax_url: {
 				scheme: '',
 				host: '',
 				path: ''
@@ -73,7 +84,6 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	 *
 	 * This will not work 100% of the time, such as if an Admin Ajax handler is
 	 * specifically looking for a $_GET param vs a $_POST param.
-	 * @todo We could rewrite the REQUEST_METHOD and $_POST to $_GET when wp_customize_preview_ajax.
 	 *
 	 * @param {object} options Options.
 	 * @param {string} options.type Type.
@@ -83,13 +93,16 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	 * @returns {void}
 	 */
 	component.prefilterAjax = function prefilterAjax( options, originalOptions, xhr ) {
-		var requestMethod, urlParser, queryVars;
+		var requestMethod, urlParser, queryVars, isMatchingHomeUrl, isMatchingRestUrl, isMatchingAdminAjaxUrl;
 
 		urlParser = document.createElement( 'a' );
 		urlParser.href = options.url;
 
-		// @todo Handle admin_ajax and rest_api requests differently?
-		if ( urlParser.host !== component.data.home_url.host || 0 !== urlParser.pathname.indexOf( component.data.home_url.path ) ) {
+		isMatchingHomeUrl = urlParser.host === component.data.home_url.host && 0 === urlParser.pathname.indexOf( component.data.home_url.path );
+		isMatchingRestUrl = urlParser.host === component.data.rest_api_url.host && 0 === urlParser.pathname.indexOf( component.data.rest_api_url.path );
+		isMatchingAdminAjaxUrl = urlParser.host === component.data.admin_ajax_url.host && 0 === urlParser.pathname.indexOf( component.data.admin_ajax_url.path );
+
+		if ( ! isMatchingHomeUrl && ! isMatchingRestUrl && ! isMatchingAdminAjaxUrl ) {
 			return;
 		}
 
@@ -125,7 +138,7 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 		}
 		queryVars = component.getCustomizeQueryVars();
 		queryVars.wp_customize_preview_ajax = 'true';
-		options.data += jQuery.param( queryVars );
+		options.data += $.param( queryVars );
 	};
 
 	return component;

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -145,7 +145,10 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	/**
 	 * Handle form submissions.
 	 *
-	 * Implements todo in https://github.com/xwp/wordpress-develop/blob/4.5.3/src/wp-includes/js/customize-preview.js#L69-L73
+	 * This fixes Core ticket {@link https://core.trac.wordpress.org/ticket/20714|#20714: Theme customizer: Impossible to preview a search results page}
+	 * Implements todo in {@link https://github.com/xwp/wordpress-develop/blob/4.5.3/src/wp-includes/js/customize-preview.js#L69-L73}
+	 *
+	 * @returns {void}
 	 */
 	component.handleFormSubmissions = function handleFormSubmissions() {
 		$( function() {
@@ -170,11 +173,14 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 
 			/*
 			 * If the default wasn't prevented already (in which case the form
-			 * submission is already being handled by JS), and if the method is
-			 * GET and its action points to a URL on this site, then take the
-			 * serialized form data and add it as a query string to the action
-			 * URL and send this in a url message to the Customizer pane so that
-			 * it will be loaded.
+			 * submission is already being handled by JS), and if it has a GET
+			 * request method, then take the serialized form data and add it as
+			 * a query string to the action URL and send this in a url message
+			 * to the Customizer pane so that it will be loaded. If the form's
+			 * action points to a non-previewable URL, the the Customizer pane's
+			 * previewUrl setter will reject it so that the form submission is
+			 * a no-op, which is the same behavior as when clicking a link to an
+			 * external site in the preview.
 			 */
 			if ( ! event.isDefaultPrevented() && 'GET' === this.method.toUpperCase() ) {
 				urlParser = document.createElement( 'a' );
@@ -183,7 +189,6 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 					urlParser.search += '&';
 				}
 				urlParser.search += $( this ).serialize();
-
 				api.preview.send( 'url', urlParser.href );
 			}
 

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -1,0 +1,1 @@
+// @todo Inject customized state into all Ajax requests back to the site? All can be taken from Customize REST Resources.

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -1130,7 +1130,7 @@ class Customize_Snapshot_Manager {
 		}
 		$wp_admin_bar->add_menu( array(
 			'id' => 'exit-customize-snapshot',
-			'title' => __( 'Exit Snapshot', 'customize-snapshots' ),
+			'title' => __( 'Exit Snapshot Preview', 'customize-snapshots' ),
 			'href' => remove_query_arg( 'customize_snapshot_uuid' ),
 			'meta' => array(
 				'class' => 'ab-item ab-customize-snapshots-item',

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -562,7 +562,6 @@ class Customize_Snapshot_Manager {
 				'home_url' => wp_parse_url( home_url( '/' ) ),
 				'l10n' => array(
 					'restoreSessionPrompt' => __( 'It seems you may have inadvertently navigated away from previewing a customized state. Would you like to restore the snapshot context?', 'customize-snapshots' ),
-					'leaveSessionPrompt' => __( 'You\'re about to leave previewing our snapshotted customized state. Would you like to continue?', 'customize-snapshots' ),
 				),
 			);
 			wp_add_inline_script(

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -552,7 +552,7 @@ class Customize_Snapshot_Manager {
 	 * Enqueue Customizer frontend scripts.
 	 */
 	public function enqueue_frontend_scripts() {
-		if ( $this->snapshot || current_user_can( 'customize' ) ) {
+		if ( $this->snapshot ) {
 			$handle = 'customize-snapshots-frontend';
 			wp_enqueue_script( $handle );
 

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -93,6 +93,7 @@ class Customize_Snapshot_Manager {
 		add_action( 'template_redirect', array( $this, 'show_theme_switch_error' ) );
 
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_controls_scripts' ) );
+		add_action( 'customize_preview_init', array( $this, 'customize_preview_init' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
 
 		add_action( 'customize_controls_init', array( $this, 'add_snapshot_uuid_to_return_url' ) );
@@ -547,6 +548,20 @@ class Customize_Snapshot_Manager {
 			'data',
 			sprintf( 'var _customizeSnapshots = %s;', wp_json_encode( $exports ) )
 		);
+	}
+
+	/**
+	 * Set up Customizer preview.
+	 */
+	public function customize_preview_init() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_preview_scripts' ) );
+	}
+
+	/**
+	 * Enqueue Customizer preview scripts.
+	 */
+	public function enqueue_preview_scripts() {
+		wp_enqueue_script( 'customize-snapshots-preview' );
 	}
 
 	/**

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -101,7 +101,7 @@ class Customize_Snapshot_Manager {
 		add_filter( 'customize_refresh_nonces', array( $this, 'filter_customize_refresh_nonces' ) );
 		add_action( 'admin_bar_menu', array( $this, 'customize_menu' ), 41 );
 		add_action( 'admin_bar_menu', array( $this, 'remove_all_non_snapshot_admin_bar_links' ), 100000 );
-		add_action( 'wp_print_styles', array( $this, 'print_admin_bar_styles' ) );
+		add_action( 'wp_before_admin_bar_render', array( $this, 'print_admin_bar_styles' ) );
 
 		add_filter( 'wp_insert_post_data', array( $this, 'prepare_snapshot_post_content_for_publish' ) );
 		add_action( 'customize_save_after', array( $this, 'publish_snapshot_with_customize_save_after' ) );
@@ -1012,6 +1012,7 @@ class Customize_Snapshot_Manager {
 	public function customize_menu( $wp_admin_bar ) {
 		add_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' );
 		$this->replace_customize_link( $wp_admin_bar );
+		$this->add_resume_snapshot_link( $wp_admin_bar );
 		$this->add_post_edit_screen_link( $wp_admin_bar );
 		$this->add_snapshot_exit_link( $wp_admin_bar );
 	}
@@ -1020,19 +1021,23 @@ class Customize_Snapshot_Manager {
 	 * Print admin bar styles.
 	 */
 	public function print_admin_bar_styles() {
-		if ( ! $this->snapshot ) {
-			return;
-		}
 		?>
 		<style type="text/css">
-		#wpadminbar #wp-admin-bar-inspect-customize-snapshot > .ab-item:before {
-			content: "\f179";
-			top: 2px;
-		}
-		#wpadminbar #wp-admin-bar-exit-customize-snapshot > .ab-item:before {
-			content: "\f158";
-			top: 2px;
-		}
+			#wpadminbar #wp-admin-bar-resume-customize-snapshot {
+				display: none;
+			}
+			#wpadminbar #wp-admin-bar-resume-customize-snapshot > .ab-item:before {
+				content: "\f531";
+				top: 2px;
+			}
+			#wpadminbar #wp-admin-bar-inspect-customize-snapshot > .ab-item:before {
+				content: "\f179";
+				top: 2px;
+			}
+			#wpadminbar #wp-admin-bar-exit-customize-snapshot > .ab-item:before {
+				content: "\f158";
+				top: 2px;
+			}
 		</style>
 		<?php
 	}
@@ -1073,6 +1078,22 @@ class Customize_Snapshot_Manager {
 
 		$customize_node->meta['class'] .= ' ab-customize-snapshots-item';
 		$wp_admin_bar->add_menu( (array) $customize_node );
+	}
+
+	/**
+	 * Adds a link to resume snapshot previewing.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
+	 */
+	public function add_resume_snapshot_link( $wp_admin_bar ) {
+		$wp_admin_bar->add_menu( array(
+			'id' => 'resume-customize-snapshot',
+			'title' => __( 'Resume Snapshot Preview', 'customize-snapshots' ),
+			'href' => '#',
+			'meta' => array(
+				'class' => 'ab-item ab-customize-snapshots-item',
+			),
+		) );
 	}
 
 	/**

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -292,8 +292,8 @@ class Customize_Snapshot_Manager {
 	public function should_import_and_preview_snapshot( Customize_Snapshot $snapshot ) {
 		global $pagenow;
 
-		// Ignore if in the admin.
-		if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) && 'customize.php' !== $pagenow ) {
+		// Ignore if in the admin, but not Admin Ajax or Customizer.
+		if ( is_admin() && ! in_array( $pagenow, array( 'admin-ajax.php', 'customize.php' ), true ) ) {
 			return false;
 		}
 
@@ -316,7 +316,7 @@ class Customize_Snapshot_Manager {
 		 * Note that wp.customize.Snapshots.extendPreviewerQuery() will extend the
 		 * previewer data to include the current snapshot UUID.
 		 */
-		if ( count( $this->customize_manager->unsanitized_post_values() ) > 0 ) {
+		if ( $this->customize_manager && count( $this->customize_manager->unsanitized_post_values() ) > 0 ) {
 			return false;
 		}
 

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -199,9 +199,10 @@ class Customize_Snapshot_Manager {
 	 * @return true|\WP_Error Returns true if previewable, or `WP_Error` if cannot.
 	 */
 	public function should_import_and_preview_snapshot( Customize_Snapshot $snapshot ) {
+		global $pagenow;
 
 		// Ignore if in the admin.
-		if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+		if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) && 'customize.php' !== $pagenow ) {
 			return false;
 		}
 

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -579,6 +579,7 @@ class Customize_Snapshot_Manager {
 				'home_url' => wp_parse_url( home_url( '/' ) ),
 				'l10n' => array(
 					'restoreSessionPrompt' => __( 'It seems you may have inadvertently navigated away from previewing a customized state. Would you like to restore the snapshot context?', 'customize-snapshots' ),
+					'leaveSessionPrompt' => __( 'You\'re about to leave previewing our snapshotted customized state. Would you like to continue?', 'customize-snapshots' ),
 				),
 			);
 			wp_add_inline_script(

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -198,6 +198,11 @@ class Customize_Snapshot_Manager {
 	 */
 	public function should_import_and_preview_snapshot( Customize_Snapshot $snapshot ) {
 
+		// Ignore if in the admin.
+		if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+			return false;
+		}
+
 		if ( is_wp_error( $this->get_theme_switch_error( $snapshot ) ) ) {
 			return false;
 		}

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -683,6 +683,7 @@ class Customize_Snapshot_Manager {
 
 		$handle = 'customize-snapshots-preview';
 		wp_enqueue_script( $handle );
+		wp_enqueue_style( $handle );
 
 		$exports = array(
 			'home_url' => wp_parse_url( home_url( '/' ) ),

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -570,13 +570,16 @@ class Customize_Snapshot_Manager {
 	 * Enqueue Customizer frontend scripts.
 	 */
 	public function enqueue_frontend_scripts() {
-		if ( $this->snapshot ) {
+		if ( $this->snapshot || current_user_can( 'customize' ) ) {
 			$handle = 'customize-snapshots-frontend';
 			wp_enqueue_script( $handle );
 
 			$exports = array(
-				'uuid' => $this->snapshot->uuid(),
+				'uuid' => $this->snapshot ? $this->snapshot->uuid() : null,
 				'home_url' => wp_parse_url( home_url( '/' ) ),
+				'l10n' => array(
+					'restoreSessionPrompt' => __( 'It seems you may have inadvertently navigated away from previewing a customized state. Would you like to restore the snapshot context?', 'customize-snapshots' ),
+				),
 			);
 			wp_add_inline_script(
 				$handle,

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -96,5 +96,10 @@ class Plugin extends Plugin_Base {
 		$src = $this->dir_url . 'css/customize-snapshots' . $min . '.css';
 		$deps = array( 'wp-jquery-ui-dialog' );
 		$wp_styles->add( $handle, $src, $deps );
+
+		$handle = 'customize-snapshots-preview';
+		$src = $this->dir_url . 'css/customize-snapshots-preview' . $min . '.css';
+		$deps = array( 'customize-preview' );
+		$wp_styles->add( $handle, $src, $deps );
 	}
 }

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -71,6 +71,11 @@ class Plugin extends Plugin_Base {
 		$deps = array( 'jquery', 'jquery-ui-dialog', 'wp-util', 'customize-controls' );
 		$wp_scripts->add( $handle, $src, $deps );
 
+		$handle = 'customize-snapshots-preview';
+		$src = $this->dir_url . 'js/customize-snapshots-preview' . $min . '.js';
+		$deps = array( 'customize-preview' );
+		$wp_scripts->add( $handle, $src, $deps );
+
 		$handle = 'customize-snapshots-frontend';
 		$src = $this->dir_url . 'js/customize-snapshots-frontend' . $min . '.js';
 		$deps = array( 'jquery', 'underscore' );

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -65,9 +65,16 @@ class Plugin extends Plugin_Base {
 	 */
 	public function register_scripts( \WP_Scripts $wp_scripts ) {
 		$min = ( SCRIPT_DEBUG ? '' : '.min' );
+
+		$handle = 'customize-snapshots';
 		$src = $this->dir_url . 'js/customize-snapshots' . $min . '.js';
 		$deps = array( 'jquery', 'jquery-ui-dialog', 'wp-util', 'customize-controls' );
-		$wp_scripts->add( $this->slug, $src, $deps );
+		$wp_scripts->add( $handle, $src, $deps );
+
+		$handle = 'customize-snapshots-frontend';
+		$src = $this->dir_url . 'js/customize-snapshots-frontend' . $min . '.js';
+		$deps = array( 'jquery', 'underscore' );
+		$wp_scripts->add( $handle, $src, $deps );
 	}
 
 	/**
@@ -79,8 +86,10 @@ class Plugin extends Plugin_Base {
 	 */
 	public function register_styles( \WP_Styles $wp_styles ) {
 		$min = ( SCRIPT_DEBUG ? '' : '.min' );
+
+		$handle = 'customize-snapshots';
 		$src = $this->dir_url . 'css/customize-snapshots' . $min . '.css';
 		$deps = array( 'wp-jquery-ui-dialog' );
-		$wp_styles->add( $this->slug, $src, $deps );
+		$wp_styles->add( $handle, $src, $deps );
 	}
 }

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -105,7 +105,7 @@ class Post_Type {
 		register_post_type( static::SLUG, $args );
 
 		add_filter( 'post_type_link', array( $this, 'filter_post_type_link' ), 10, 2 );
-		add_action( 'add_meta_boxes_' . static::SLUG, array( $this, 'remove_publish_metabox' ), 100 );
+		add_action( 'add_meta_boxes_' . static::SLUG, array( $this, 'remove_slug_metabox' ), 100 );
 		add_action( 'load-revision.php', array( $this, 'suspend_kses_for_snapshot_revision_restore' ) );
 		add_filter( 'get_the_excerpt', array( $this, 'filter_snapshot_excerpt' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'filter_post_row_actions' ), 10, 2 );
@@ -176,7 +176,7 @@ class Post_Type {
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function remove_publish_metabox() {
+	public function remove_slug_metabox() {
 		remove_meta_box( 'slugdiv', static::SLUG, 'normal' );
 	}
 
@@ -594,20 +594,20 @@ class Post_Type {
 	/**
 	 * Display snapshot save error on post list table.
 	 *
-	 * @param array    $status Display status.
-	 * @param \WP_Post $post Post object.
+	 * @param array    $states Display states.
+	 * @param \WP_Post $post   Post object.
 	 *
 	 * @return mixed
 	 */
-	public function display_post_states( $status, $post ) {
+	public function display_post_states( $states, $post ) {
 		if ( static::SLUG !== $post->post_type ) {
-			return $status;
+			return $states;
 		}
 		$maybe_error = get_post_meta( $post->ID, 'snapshot_error_on_publish', true );
 		if ( $maybe_error ) {
-			$status['snapshot_error'] = __( 'Error on publish', 'customize-snapshots' );
+			$states['snapshot_error'] = __( 'Error on publish', 'customize-snapshots' );
 		}
-		return $status;
+		return $states;
 	}
 
 	/**

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,9 @@ Allow Customizer states to be drafted, and previewed with a private URL.
 
 ## Description ##
 
-Customize Snapshots save the state of a Customizer session so it can be shared or even publish at a future date. A snapshot can be shared with a private URL to both authenticated and non authenticated users. This means anyone can preview a snapshot's settings on the front-end without loading the Customizer, and authenticated users can load the snapshot into the Customizer and publish or amend the settings at any time.
+Customize Snapshots save the state of a Customizer session so it can be shared or even published at a future date. A snapshot can be shared with a private URL to both authenticated and non authenticated users. This means anyone can preview a snapshot's settings on the front-end without loading the Customizer, and authenticated users can load the snapshot into the Customizer and publish or amend the settings at any time.
 
-Requires PHP 5.3+.
-
-**Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
+Requires PHP 5.3+. **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
 
 ## Screenshots ##
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Customize Snapshots save the state of a Customizer session so it can be shared o
 
 Requires PHP 5.3+. **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
 
-=== Persistent Object Caching ===
+= Persistent Object Caching =
 
 Plugins and themes may currently only use `is_customize_preview()` to
 decide whether or not they can store a value in the object cache. For
@@ -27,7 +27,7 @@ is `true`, or they should include the `CustomizeSnapshots\current_snapshot_uuid(
 
 Example of bypassing object cache when previewing settings inside the Customizer preview or on the frontend via snapshots:
 
-<pre lang=php>
+<pre lang="php">
 if ( function_exists( 'CustomizeSnapshots\is_previewing_settings' ) ) {
 	$bypass_object_cache = CustomizeSnapshots\is_previewing_settings();
 } else {

--- a/readme.txt
+++ b/readme.txt
@@ -11,12 +11,42 @@ Allow Customizer states to be drafted, and previewed with a private URL.
 
 == Description ==
 
-Customize Snapshots save the state of a Customizer session so it can be shared or even publish at a future date. A snapshot can be shared with a private URL to both authenticated and non authenticated users. This means anyone can preview a snapshot's settings on the front-end without loading the Customizer, and authenticated users can load the snapshot into the Customizer and publish or amend the settings at any time.
+Customize Snapshots save the state of a Customizer session so it can be shared or even published at a future date. A snapshot can be shared with a private URL to both authenticated and non authenticated users. This means anyone can preview a snapshot's settings on the front-end without loading the Customizer, and authenticated users can load the snapshot into the Customizer and publish or amend the settings at any time.
 
-Requires PHP 5.3+.
+Requires PHP 5.3+. **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
 
-**Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customize-snapshots). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customize-snapshots) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customize-snapshots).**
+=== Persistent Object Caching ===
 
+Plugins and themes may currently only use `is_customize_preview()` to
+decide whether or not they can store a value in the object cache. For
+example, see `Twenty_Eleven_Ephemera_Widget::widget()`. However, when
+viewing a snapshot on the frontend, the `is_customize_preview()` method
+will return `false`. Plugins and themes that store values in the object
+cache must either skip storing in the object cache when `CustomizeSnapshots\is_previewing_settings()`
+is `true`, or they should include the `CustomizeSnapshots\current_snapshot_uuid()` in the cache key.
+
+Example of bypassing object cache when previewing settings inside the Customizer preview or on the frontend via snapshots:
+
+<pre lang=php>
+if ( function_exists( 'CustomizeSnapshots\is_previewing_settings' ) ) {
+	$bypass_object_cache = CustomizeSnapshots\is_previewing_settings();
+} else {
+	$bypass_object_cache = is_customize_preview();
+}
+$contents = null;
+if ( ! $bypass_object_cache ) {
+	$contents = wp_cache_get( 'something', 'myplugin' );
+}
+if ( ! $contents ) {
+	ob_start();
+	myplugin_do_something();
+	$contents = ob_get_clean();
+	echo $contents;
+}
+if ( ! $bypass_object_cache ) {
+	wp_cache_set( 'something', $contents, 'myplugin', HOUR_IN_SECONDS );
+}
+</pre>
 
 == Screenshots ==
 

--- a/tests/php/test-class-ajax-customize-snapshot-manager.php
+++ b/tests/php/test-class-ajax-customize-snapshot-manager.php
@@ -55,6 +55,7 @@ class Test_Ajax_Customize_Snapshot_Manager extends \WP_Ajax_UnitTestCase {
 		parent::setUp();
 
 		remove_all_actions( 'wp_ajax_customize_save' );
+		remove_all_actions( 'wp_ajax_customize_update_snapshot' );
 		$this->plugin = new Plugin();
 		$this->set_input_vars();
 		$this->plugin->init();

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -232,6 +232,35 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests is_previewing_settings.
+	 *
+	 * @covers Customize_Snapshot_Manager::is_previewing_settings()
+	 */
+	public function test_is_previewing_settings() {
+		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
+		$this->plugin->customize_snapshot_manager->post_type->save( array(
+			'uuid' => self::UUID,
+			'data' => array( 'blogname' => array( 'value' => 'Foo' ) ),
+		) );
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$manager->init();
+		$manager->preview_snapshot_settings();
+		$this->assertTrue( $manager->is_previewing_settings() );
+	}
+
+	/**
+	 * Tests is_previewing_settings.
+	 *
+	 * @covers Customize_Snapshot_Manager::is_previewing_settings()
+	 */
+	public function test_is_previewing_settings_via_preview_init() {
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->assertFalse( $manager->is_previewing_settings() );
+		do_action( 'customize_preview_init' );
+		$this->assertTrue( $manager->is_previewing_settings() );
+	}
+
+	/**
 	 * Tests preview_snapshot_settings.
 	 *
 	 * @covers Customize_Snapshot_Manager::preview_snapshot_settings()

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -158,7 +158,7 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 		$this->assertInstanceOf( 'CustomizeSnapshots\Post_Type', $manager->post_type );
 		$this->assertInstanceOf( 'CustomizeSnapshots\Customize_Snapshot', $manager->snapshot() );
 		$this->assertEquals( 0, has_action( 'init', array( $manager, 'create_post_type' ) ) );
-		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', array( $manager, 'enqueue_scripts' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', array( $manager, 'enqueue_controls_scripts' ) ) );
 		$this->assertEquals( 10, has_action( 'wp_ajax_customize_update_snapshot', array( $manager, 'handle_update_snapshot_request' ) ) );
 	}
 
@@ -344,14 +344,14 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	/**
 	 * Test enqueue scripts.
 	 *
-	 * @see Customize_Snapshot_Manager::enqueue_scripts()
+	 * @see Customize_Snapshot_Manager::enqueue_controls_scripts()
 	 */
 	function test_enqueue_scripts() {
 		$this->plugin->register_scripts( wp_scripts() );
 		$this->plugin->register_styles( wp_styles() );
 		$manager = new Customize_Snapshot_Manager( $this->plugin );
 		$manager->init();
-		$manager->enqueue_scripts();
+		$manager->enqueue_controls_scripts();
 		$this->assertTrue( wp_script_is( $this->plugin->slug, 'enqueued' ) );
 		$this->assertTrue( wp_style_is( $this->plugin->slug, 'enqueued' ) );
 	}

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -100,6 +100,7 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 		unset( $GLOBALS['wp_scripts'] );
 		unset( $GLOBALS['wp_styles'] );
 		unset( $_REQUEST['customize_snapshot_uuid'] );
+		unset( $_REQUEST['wp_customize_preview_ajax'] );
 		parent::clean_up_global_scope();
 	}
 
@@ -187,21 +188,106 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests init.
+	 * Tests init hooks.
 	 *
 	 * @covers Customize_Snapshot_Manager::init()
 	 */
-	public function test_init() {
-		$this->markTestIncomplete();
+	public function test_init_hooks() {
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$manager->init();
+
+		$this->assertInstanceOf( __NAMESPACE__ . '\Post_Type', $manager->post_type );
+		$this->assertEquals( 10, has_action( 'template_redirect', array( $manager, 'show_theme_switch_error' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', array( $manager, 'enqueue_controls_scripts' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_preview_init', array( $manager, 'customize_preview_init' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', array( $manager, 'enqueue_frontend_scripts' ) ) );
+
+		$this->assertEquals( 10, has_action( 'customize_controls_init', array( $manager, 'add_snapshot_uuid_to_return_url' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_controls_print_footer_scripts', array( $manager, 'render_templates' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_save', array( $manager, 'check_customize_publish_authorization' ) ) );
+		$this->assertEquals( 10, has_filter( 'customize_refresh_nonces', array( $manager, 'filter_customize_refresh_nonces' ) ) );
+		$this->assertEquals( 41, has_action( 'admin_bar_menu', array( $manager, 'customize_menu' ) ) );
+		$this->assertEquals( 100000, has_action( 'admin_bar_menu', array( $manager, 'remove_all_non_snapshot_admin_bar_links' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_before_admin_bar_render', array( $manager, 'print_admin_bar_styles' ) ) );
+
+		$this->assertEquals( 10, has_filter( 'wp_insert_post_data', array( $manager, 'prepare_snapshot_post_content_for_publish' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_save_after', array( $manager, 'publish_snapshot_with_customize_save_after' ) ) );
+		$this->assertEquals( 10, has_action( 'transition_post_status', array( $manager, 'save_settings_with_publish_snapshot' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_ajax_customize_update_snapshot', array( $manager, 'handle_update_snapshot_request' ) ) );
+	}
+
+	/**
+	 * Tests init hooks.
+	 *
+	 * @covers Customize_Snapshot_Manager::init()
+	 * @covers Customize_Snapshot_Manager::read_current_snapshot_uuid()
+	 */
+	public function test_read_current_snapshot_uuid() {
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->assertFalse( $manager->read_current_snapshot_uuid() );
+		$this->assertNull( $manager->current_snapshot_uuid );
+
+		$_REQUEST['customize_snapshot_uuid'] = 'bad';
+		$this->assertFalse( $manager->read_current_snapshot_uuid() );
+		$this->assertNull( $manager->current_snapshot_uuid );
+
+		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
+		$this->assertTrue( $manager->read_current_snapshot_uuid() );
+		$this->assertEquals( self::UUID, $manager->current_snapshot_uuid );
+
+		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$manager->init();
+		$this->assertEquals( self::UUID, $manager->current_snapshot_uuid );
+	}
+
+	/**
+	 * Tests load_snapshot.
+	 *
+	 * @covers Customize_Snapshot_Manager::init()
+	 * @covers Customize_Snapshot_Manager::load_snapshot()
+	 */
+	public function test_load_snapshot() {
+		global $wp_actions;
+		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
+		$this->plugin->customize_snapshot_manager->post_type->save( array(
+			'uuid' => self::UUID,
+			'data' => array(
+				'blogname' => array( 'value' => 'Hello' ),
+			),
+			'status' => 'draft',
+		) );
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		unset( $wp_actions['setup_theme'] );
+		unset( $wp_actions['wp_loaded'] );
+		$manager->init();
+		$this->assertNotEmpty( $manager->customize_manager );
+		$this->assertNotEmpty( $manager->snapshot );
+
+		$this->assertEquals( 10, has_action( 'setup_theme', array( $manager, 'import_snapshot_data' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_head', 'wp_no_robots' ) );
+		$this->assertEquals( 11, has_action( 'wp_loaded', array( $manager, 'preview_snapshot_settings' ) ) );
 	}
 
 	/**
 	 * Tests setup_preview_ajax_requests.
 	 *
+	 * @covers Customize_Snapshot_Manager::init()
 	 * @covers Customize_Snapshot_Manager::setup_preview_ajax_requests()
 	 */
 	public function test_setup_preview_ajax_requests() {
-		$this->markTestIncomplete();
+		wp_set_current_user( $this->user_id );
+		$_REQUEST['wp_customize_preview_ajax'] = 'true';
+		$_POST['customized'] = wp_slash( wp_json_encode( array( 'blogname' => 'Foo' ) ) );
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->do_customize_boot_actions( true );
+		$this->assertTrue( is_customize_preview() );
+		$manager->init();
+		$this->assertEquals( 12, has_action( 'wp_loaded', array( $manager, 'setup_preview_ajax_requests' ) ) );
+		do_action( 'wp_loaded' );
+
+		$this->assertFalse( has_action( 'shutdown', array( $this->wp_customize, 'customize_preview_signature' ) ) );
+		$this->assertEquals( 5, has_action( 'parse_request', array( $manager, 'override_request_method' ) ) );
 	}
 
 	/**
@@ -210,7 +296,33 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	 * @covers Customize_Snapshot_Manager::override_request_method()
 	 */
 	public function test_override_request_method() {
-		$this->markTestIncomplete();
+		global $wp;
+
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->assertFalse( $manager->override_request_method() );
+
+		$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'GET';
+		$wp->query_vars['rest_route'] = '/wp/v1/foo';
+		$this->assertFalse( $manager->override_request_method() );
+		unset( $wp->query_vars['rest_route'] );
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'GET';
+		$this->assertFalse( $manager->override_request_method() );
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'BAD';
+		$this->assertFalse( $manager->override_request_method() );
+
+		$_GET = wp_slash( array( 'foo' => '1' ) );
+		$_POST = wp_slash( array( 'bar' => '2' ) );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'GET';
+		$this->assertTrue( $manager->override_request_method() );
+		$this->assertEquals( 'GET', $_SERVER['REQUEST_METHOD'] );
+		$this->assertEquals( 'foo=1&bar=2', $_SERVER['QUERY_STRING'] );
+		$this->assertArrayHasKey( 'foo', $_GET );
+		$this->assertArrayHasKey( 'bar', $_GET );
 	}
 
 	/**

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -196,6 +196,24 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests setup_preview_ajax_requests.
+	 *
+	 * @covers Customize_Snapshot_Manager::setup_preview_ajax_requests()
+	 */
+	public function test_setup_preview_ajax_requests() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Tests override_request_method.
+	 *
+	 * @covers Customize_Snapshot_Manager::override_request_method()
+	 */
+	public function test_override_request_method() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Tests doing_customize_save_ajax.
 	 *
 	 * @covers Customize_Snapshot_Manager::doing_customize_save_ajax()

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -362,7 +362,13 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	 * @covers Customize_Snapshot_Manager::is_theme_active()
 	 */
 	public function test_is_theme_active() {
-		$this->markTestIncomplete();
+		global $wp_customize;
+		$wp_customize = null; // WPCS: global override ok.
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->assertTrue( $manager->is_theme_active() );
+
+		$manager->ensure_customize_manager();
+		$this->assertTrue( $manager->is_theme_active() );
 	}
 
 	/**

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -347,7 +347,13 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	 * @covers Customize_Snapshot_Manager::ensure_customize_manager()
 	 */
 	public function test_ensure_customize_manager() {
-		$this->markTestIncomplete();
+		global $wp_customize;
+		$wp_customize = null; // WPCS: global override ok.
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->assertEmpty( $manager->customize_manager );
+		$manager->ensure_customize_manager();
+		$this->assertInstanceOf( 'WP_Customize_Manager', $manager->customize_manager );
+		$this->assertInstanceOf( 'WP_Customize_Manager', $wp_customize );
 	}
 
 	/**

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -331,7 +331,14 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	 * @covers Customize_Snapshot_Manager::doing_customize_save_ajax()
 	 */
 	public function test_doing_customize_save_ajax() {
-		$this->markTestIncomplete();
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$this->assertFalse( $manager->doing_customize_save_ajax() );
+
+		$_REQUEST['action'] = 'foo';
+		$this->assertFalse( $manager->doing_customize_save_ajax() );
+
+		$_REQUEST['action'] = 'customize_save';
+		$this->assertTrue( $manager->doing_customize_save_ajax() );
 	}
 
 	/**

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -596,24 +596,6 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 		ob_start();
 		$manager->print_admin_bar_styles();
 		$contents = ob_get_clean();
-		$this->assertEmpty( $contents );
-
-		$this->manager->post_type->save( array(
-			'uuid' => self::UUID,
-			'data' => array(
-				'blogname' => array(
-					'value' => 'Hello',
-				),
-			),
-			'status' => 'draft',
-		) );
-		$this->go_to( home_url( '?customize_snapshot_uuid=' . self::UUID ) );
-		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
-		$manager = new Customize_Snapshot_Manager( $this->plugin );
-		$manager->init();
-		ob_start();
-		$manager->print_admin_bar_styles();
-		$contents = ob_get_clean();
 		$this->assertContains( '<style', $contents );
 	}
 
@@ -661,10 +643,11 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add_post_edit_screen_link, add_snapshot_exit_link, and remove_all_non_snapshot_admin_bar_links.
+	 * Test misc admin bar extensions.
 	 *
 	 * @covers Customize_Snapshot_Manager::add_post_edit_screen_link()
 	 * @covers Customize_Snapshot_Manager::add_snapshot_exit_link()
+	 * @covers Customize_Snapshot_Manager::add_resume_snapshot_link()
 	 * @covers Customize_Snapshot_Manager::remove_all_non_snapshot_admin_bar_links()
 	 */
 	public function test_add_post_edit_and_exit_links() {
@@ -692,6 +675,7 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 		$this->assertEmpty( $wp_admin_bar->get_node( 'inspect-customize-snapshot' ) );
 		$this->assertEmpty( $wp_admin_bar->get_node( 'exit-customize-snapshot' ) );
 		$this->assertNotEmpty( $wp_admin_bar->get_node( 'wporg' ) );
+		$this->assertNotEmpty( $wp_admin_bar->get_node( 'resume-customize-snapshot' ) );
 
 		$this->go_to( home_url( '?customize_snapshot_uuid=' . self::UUID ) );
 		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
@@ -705,6 +689,7 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $wp_admin_bar->get_node( 'inspect-customize-snapshot' ) );
 		$this->assertNotEmpty( $wp_admin_bar->get_node( 'exit-customize-snapshot' ) );
 		$this->assertEmpty( $wp_admin_bar->get_node( 'wporg' ) );
+		$this->assertNotEmpty( $wp_admin_bar->get_node( 'resume-customize-snapshot' ) );
 	}
 
 	/**

--- a/tests/php/test-class-customize-snapshot-manager.php
+++ b/tests/php/test-class-customize-snapshot-manager.php
@@ -94,13 +94,21 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Clean up global scope.
+	 */
+	function clean_up_global_scope() {
+		unset( $GLOBALS['wp_scripts'] );
+		unset( $GLOBALS['wp_styles'] );
+		parent::clean_up_global_scope();
+	}
+
+	/**
 	 * Tear down.
 	 */
 	function tearDown() {
 		$this->wp_customize = null;
 		$this->manager = null;
 		unset( $GLOBALS['wp_customize'] );
-		unset( $GLOBALS['wp_scripts'] );
 		unset( $GLOBALS['screen'] );
 		$_REQUEST = array();
 		parent::tearDown();
@@ -342,18 +350,40 @@ class Test_Customize_Snapshot_Manager extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test enqueue scripts.
+	 * Test enqueue controls scripts.
 	 *
 	 * @see Customize_Snapshot_Manager::enqueue_controls_scripts()
 	 */
-	function test_enqueue_scripts() {
+	function test_enqueue_controls_scripts() {
 		$this->plugin->register_scripts( wp_scripts() );
 		$this->plugin->register_styles( wp_styles() );
 		$manager = new Customize_Snapshot_Manager( $this->plugin );
 		$manager->init();
 		$manager->enqueue_controls_scripts();
-		$this->assertTrue( wp_script_is( $this->plugin->slug, 'enqueued' ) );
-		$this->assertTrue( wp_style_is( $this->plugin->slug, 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'customize-snapshots', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'customize-snapshots', 'enqueued' ) );
+	}
+
+	/**
+	 * Test enqueue frontend scripts.
+	 *
+	 * @see Customize_Snapshot_Manager::enqueue_frontend_scripts()
+	 */
+	function test_enqueue_frontend_scripts() {
+		$this->plugin->register_scripts( wp_scripts() );
+		$this->plugin->register_styles( wp_styles() );
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$manager->init();
+		$this->assertFalse( wp_script_is( 'customize-snapshots-frontend', 'enqueued' ) );
+		$manager->enqueue_frontend_scripts();
+		$this->assertFalse( wp_script_is( 'customize-snapshots-frontend', 'enqueued' ) );
+
+		$_REQUEST['customize_snapshot_uuid'] = self::UUID;
+		$manager = new Customize_Snapshot_Manager( $this->plugin );
+		$manager->init();
+		$this->assertFalse( wp_script_is( 'customize-snapshots-frontend', 'enqueued' ) );
+		$manager->enqueue_frontend_scripts();
+		$this->assertTrue( wp_script_is( 'customize-snapshots-frontend', 'enqueued' ) );
 	}
 
 	/**

--- a/tests/php/test-class-post-type.php
+++ b/tests/php/test-class-post-type.php
@@ -49,7 +49,7 @@ class Test_Post_type extends \WP_UnitTestCase {
 		$this->assertTrue( post_type_exists( Post_Type::SLUG ) );
 
 		$this->assertEquals( 10, has_filter( 'post_type_link', array( $post_type, 'filter_post_type_link' ) ) );
-		$this->assertEquals( 100, has_action( 'add_meta_boxes_' . Post_Type::SLUG, array( $post_type, 'remove_publish_metabox' ) ) );
+		$this->assertEquals( 100, has_action( 'add_meta_boxes_' . Post_Type::SLUG, array( $post_type, 'remove_slug_metabox' ) ) );
 		$this->assertEquals( 10, has_action( 'load-revision.php', array( $post_type, 'suspend_kses_for_snapshot_revision_restore' ) ) );
 		$this->assertEquals( 10, has_filter( 'get_the_excerpt', array( $post_type, 'filter_snapshot_excerpt' ) ) );
 		$this->assertEquals( 10, has_filter( 'post_row_actions', array( $post_type, 'filter_post_row_actions' ) ) );
@@ -129,23 +129,9 @@ class Test_Post_type extends \WP_UnitTestCase {
 		$this->assertTrue( ! empty( $wp_meta_boxes[ Post_Type::SLUG ]['normal']['high'][ $metabox_id ] ) );
 	}
 
-	/**
-	 * Tests remove_publish_metabox.
-	 *
-	 * @covers Post_Type::remove_publish_metabox()
-	 */
-	public function test_remove_publish_metabox() {
-		$this->markTestIncomplete();
-	}
+	/* Note: Code coverage ignored on Post_Type::remove_publish_metabox(). */
 
-	/**
-	 * Tests suspend_kses_for_snapshot_revision_restore.
-	 *
-	 * @covers Post_Type::suspend_kses_for_snapshot_revision_restore()
-	 */
-	public function test_suspend_kses_for_snapshot_revision_restore() {
-		$this->markTestIncomplete();
-	}
+	/* Note: Code coverage ignored on Post_Type::suspend_kses_for_snapshot_revision_restore(). */
 
 	/**
 	 * Test include the setting IDs in the excerpt.
@@ -643,7 +629,18 @@ class Test_Post_type extends \WP_UnitTestCase {
 	 * @covers Post_Type::display_post_states()
 	 */
 	public function test_display_post_states() {
-		$this->markTestIncomplete();
+		$post_type = new Post_Type( $this->plugin->customize_snapshot_manager );
+
+		$post_id = $post_type->save( array(
+			'uuid' => self::UUID,
+			'data' => array( 'foo' => array( 'value' => 'bar' ) ),
+		) );
+		$states = $post_type->display_post_states( array(), get_post( $post_id ) );
+		$this->assertArrayNotHasKey( 'snapshot_error', $states );
+
+		update_post_meta( $post_id, 'snapshot_error_on_publish', true );
+		$states = $post_type->display_post_states( array(), get_post( $post_id ) );
+		$this->assertArrayHasKey( 'snapshot_error', $states );
 	}
 
 	/**

--- a/tests/test-customize-snapshots.php
+++ b/tests/test-customize-snapshots.php
@@ -5,10 +5,23 @@
  * @package CustomizeSnapshots
  */
 
+namespace CustomizeSnapshots;
+
 /**
  * Class Test_Customize_Snapshots
  */
 class Test_Customize_Snapshots extends \WP_UnitTestCase {
+
+	/**
+	 * Clean up global scope.
+	 */
+	function clean_up_global_scope() {
+		global $customize_snapshots_plugin;
+		unset( $_REQUEST['customize_snapshot_uuid'] );
+		parent::clean_up_global_scope();
+		$customize_snapshots_plugin = new Plugin();
+		$customize_snapshots_plugin->init();
+	}
 
 	/**
 	 * Test customize_snapshots_php_version_error.
@@ -29,5 +42,31 @@ class Test_Customize_Snapshots extends \WP_UnitTestCase {
 	 */
 	function test_customize_snapshots_php_version_text() {
 		$this->assertContains( 'Customize Snapshots plugin error:', customize_snapshots_php_version_text() );
+	}
+
+	/**
+	 * Tests is_previewing_settings().
+	 *
+	 * @covers is_previewing_settings()
+	 */
+	public function test_is_previewing_settings() {
+		$this->assertFalse( is_previewing_settings() );
+		do_action( 'customize_preview_init' );
+		$this->assertTrue( is_previewing_settings() );
+	}
+
+	/**
+	 * Tests current_snapshot_uuid().
+	 *
+	 * @covers current_snapshot_uuid()
+	 */
+	public function test_current_snapshot_uuid() {
+		global $customize_snapshots_plugin;
+		$this->assertNull( current_snapshot_uuid() );
+		$uuid = '65aee1ff-af47-47df-9e14-9c69b3017cd3';
+		$_REQUEST['customize_snapshot_uuid'] = $uuid;
+		$customize_snapshots_plugin = new Plugin();
+		$customize_snapshots_plugin->init();
+		$this->assertEquals( $uuid, current_snapshot_uuid() );
 	}
 }


### PR DESCRIPTION
When previewing a snapshot on the frontend, the admin bar is modified accordingly:

<img width="763" alt="wordpress_develop_food_ _just_another_customizer-driven_site_" src="https://cloud.githubusercontent.com/assets/134745/17466597/f97c80f2-5cc7-11e6-943c-cca7e330edb2.png">
- (Unchanged) The “Customize” link takes you to the Customizer with that snapshot state applied.
- The “Inspect Snapshot” link takes you to the edit post screen (formerly submenu item under Customize).
- A new “Exit Snapshot Preview” link appears which removes the `customize_snapshot_uuid` query param from the current URL.
- All other admin bar links are removed, other than those which already contain the `customize_snapshot_uuid` query param (as in the Airplane Mode toggle shown here), or which are in-page links, such as the query monitor link.

When you are navigating around the site with a snapshot applied, the `sessionStorage` will store the UUID for this snapshot. While the JS will attempt to inject the `customize_snapshot_uuid` into all links in the document, if you _do_ navigate away from a URL that has this query param, the JS on the new non-snapshotted page will see that you have a snapshot UUID in `sessionStorage` but no snapshot in the URL, and it will add an admin bar link to prompt you to resume the snapshot preview:

<img width="524" alt="wordpress_develop_ _just_another_customizer-driven_site__and_2__vagrant_vvv_____bash_" src="https://cloud.githubusercontent.com/assets/134745/17466662/cbee8382-5cc8-11e6-92c9-949e5e20ac52.png">

This PR also ensures that Ajax requests made on the frontend include the `customize_snapshot_uuid` param so that the responses can be previewed. Additionally, Ajax requests made _inside_ the Customizer preview also now get the Customizer state added so that their responses should be previewable as well. 

Lastly, forms that have `GET` request methods (such as the search form) now are actually usable in the Customizer preview! Likewise, forms on the frontend will persist the current `customize_snapshot_uuid` in the requests. This fixes a long-standing Trac ticket [#20714](https://core.trac.wordpress.org/ticket/20714): Theme customizer: Impossible to preview a search results page. See sub-PR #72.

Fixes #47
Fixes #65 
