### PR TITLE
Add support for persisting the Customizer state through form submissions

### DIFF
--- a/css/customize-snapshots-preview.css
+++ b/css/customize-snapshots-preview.css
@@ -1,0 +1,8 @@
+form[method="post"] button[type="submit"],
+form[method="post"] button[type=""],
+form[method="post"] input[type="submit"] {
+	cursor: not-allowed;
+}
+form[method="post"] button:not([type]) {
+	cursor: not-allowed;
+}

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -42,6 +42,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		component.injectSnapshotIntoLinks();
 		component.handleExitSnapshotSessionLink();
 		component.injectSnapshotIntoAjaxRequests();
+		component.injectSnapshotIntoForms();
 	};
 
 	/**
@@ -108,7 +109,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 
 			// Inject links into initial document.
 			$( document.body ).find( linkSelectors ).each( function() {
-				component.injectLinkQueryParam( this );
+				component.injectSnapshotLinkParam( this );
 			} );
 
 			// Inject links for new elements added to the page
@@ -116,7 +117,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 				component.mutationObserver = new MutationObserver( function( mutations ) {
 					_.each( mutations, function( mutation ) {
 						$( mutation.target ).find( linkSelectors ).each( function() {
-							component.injectLinkQueryParam( this );
+							component.injectSnapshotLinkParam( this );
 						} );
 					} );
 				} );
@@ -128,7 +129,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 
 				// If mutation observers aren't available, fallback to just-in-time injection.
 				$( document.documentElement ).on( 'click focus mouseover', linkSelectors, function() {
-					component.injectLinkQueryParam( this );
+					component.injectSnapshotLinkParam( this );
 				} );
 			}
 		} );
@@ -201,7 +202,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @param {object} element.search Query string.
 	 * @returns {void}
 	 */
-	component.injectLinkQueryParam = function injectLinkQueryParam( element ) {
+	component.injectSnapshotLinkParam = function injectSnapshotLinkParam( element ) {
 		if ( component.doesLinkHaveSnapshotQueryParam( element ) || ! component.shouldLinkHaveSnapshotParam( element ) ) {
 			return;
 		}
@@ -270,6 +271,63 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 		urlParser.search += 'customize_snapshot_uuid=' + component.data.uuid;
 
 		options.url = urlParser.href;
+	};
+
+	/**
+	 * Inject snapshot into forms, allowing preview to persist through submissions.
+	 *
+	 * @returns {void}
+	 */
+	component.injectSnapshotIntoForms = function injectSnapshotIntoForms() {
+		if ( ! component.data.uuid ) {
+			return;
+		}
+		$( function() {
+
+			// Inject inputs for forms in initial document.
+			$( document.body ).find( 'form' ).each( function() {
+				component.injectSnapshotFormInput( this );
+			} );
+
+			// Inject inputs for new forms added to the page.
+			if ( 'undefined' !== typeof MutationObserver ) {
+				component.mutationObserver = new MutationObserver( function( mutations ) {
+					_.each( mutations, function( mutation ) {
+						$( mutation.target ).find( 'form' ).each( function() {
+							component.injectSnapshotFormInput( this );
+						} );
+					} );
+				} );
+				component.mutationObserver.observe( document.documentElement, {
+					childList: true,
+					subtree: true
+				} );
+			}
+		} );
+	};
+
+	/**
+	 * Inject snapshot into form inputs.
+	 *
+	 * @param {HTMLFormElement} form Form.
+	 * @returns {void}
+	 */
+	component.injectSnapshotFormInput = function injectSnapshotFormInput( form ) {
+		var urlParser;
+		if ( form.querySelector( 'input[name=customize_snapshot_uuid]' ) ) {
+			return;
+		}
+		urlParser = document.createElement( 'a' );
+		urlParser.href = form.action;
+		if ( ! component.isMatchingBaseUrl( urlParser ) ) {
+			return;
+		}
+
+		$( form ).prepend( $( '<input>', {
+			type: 'hidden',
+			name: 'customize_snapshot_uuid',
+			value: component.data.uuid
+		} ) );
 	};
 
 	return component;

--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -314,7 +314,7 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 */
 	component.injectSnapshotFormInput = function injectSnapshotFormInput( form ) {
 		var urlParser;
-		if ( form.querySelector( 'input[name=customize_snapshot_uuid]' ) ) {
+		if ( $( form ).find( 'input[name=customize_snapshot_uuid]' ).length > 0 ) {
 			return;
 		}
 		urlParser = document.createElement( 'a' );

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -158,23 +158,9 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	};
 
 	/**
-	 * Check if form is previewable (has a GET method and an action pointing to WP).
-	 *
-	 * @param {HTMLFormElement} form Form.
-	 * @returns {boolean} Is previewable.
-	 */
-	component.isFormPreviewable = function isFormPreviewable( form ) {
-		var method = form.method.toUpperCase(), urlParser;
-		if ( 'GET' !== method ) {
-			return false;
-		}
-		urlParser = document.createElement( 'a' );
-		urlParser.href = form.action;
-		return urlParser.host === component.data.home_url.host && 0 === urlParser.pathname.indexOf( component.data.home_url.path );
-	};
-
-	/**
 	 * Replace form submit handler.
+	 *
+	 * @returns {void}
 	 */
 	component.replaceFormSubmitHandler = function replaceFormSubmitHandler() {
 		var body = $( document.body );
@@ -190,7 +176,7 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 			 * URL and send this in a url message to the Customizer pane so that
 			 * it will be loaded.
 			 */
-			if ( ! event.isDefaultPrevented() && component.isFormPreviewable( this ) ) {
+			if ( ! event.isDefaultPrevented() && 'GET' === this.method.toUpperCase() ) {
 				urlParser = document.createElement( 'a' );
 				urlParser.href = this.action;
 				if ( urlParser.search.substr( 1 ).length > 1 ) {

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -41,6 +41,7 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 		_.extend( component.data, args );
 
 		component.injectSnapshotIntoAjaxRequests();
+		component.handleFormSubmissions();
 	};
 
 	/**
@@ -139,6 +140,70 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 		queryVars = component.getCustomizeQueryVars();
 		queryVars.wp_customize_preview_ajax = 'true';
 		options.data += $.param( queryVars );
+	};
+
+	/**
+	 * Handle form submissions.
+	 *
+	 * Implements todo in https://github.com/xwp/wordpress-develop/blob/4.5.3/src/wp-includes/js/customize-preview.js#L69-L73
+	 */
+	component.handleFormSubmissions = function handleFormSubmissions() {
+		$( function() {
+
+			// Defer so that we can be sure that our event handler will come after any other event handlers.
+			_.defer( function() {
+				component.replaceFormSubmitHandler();
+			} );
+		} );
+	};
+
+	/**
+	 * Check if form is previewable (has a GET method and an action pointing to WP).
+	 *
+	 * @param {HTMLFormElement} form Form.
+	 * @returns {boolean} Is previewable.
+	 */
+	component.isFormPreviewable = function isFormPreviewable( form ) {
+		var method = form.method.toUpperCase(), urlParser;
+		if ( 'GET' !== method ) {
+			return false;
+		}
+		urlParser = document.createElement( 'a' );
+		urlParser.href = form.action;
+		return urlParser.host === component.data.home_url.host && 0 === urlParser.pathname.indexOf( component.data.home_url.path );
+	};
+
+	/**
+	 * Replace form submit handler.
+	 */
+	component.replaceFormSubmitHandler = function replaceFormSubmitHandler() {
+		var body = $( document.body );
+		body.off( 'submit.preview' );
+		body.on( 'submit.preview', 'form', function( event ) {
+			var urlParser;
+
+			/*
+			 * If the default wasn't prevented already (in which case the form
+			 * submission is already being handled by JS), and if the method is
+			 * GET and its action points to a URL on this site, then take the
+			 * serialized form data and add it as a query string to the action
+			 * URL and send this in a url message to the Customizer pane so that
+			 * it will be loaded.
+			 */
+			if ( ! event.isDefaultPrevented() && component.isFormPreviewable( this ) ) {
+				urlParser = document.createElement( 'a' );
+				urlParser.href = this.action;
+				if ( urlParser.search.substr( 1 ).length > 1 ) {
+					urlParser.search += '&';
+				}
+				urlParser.search += $( this ).serialize();
+
+				api.preview.send( 'url', urlParser.href );
+			}
+
+			// Now preventDefault as is done on the normal submit.preview handler in customize-preview.js.
+			event.preventDefault();
+		});
 	};
 
 	return component;

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -145,7 +145,10 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 	/**
 	 * Handle form submissions.
 	 *
-	 * Implements todo in https://github.com/xwp/wordpress-develop/blob/4.5.3/src/wp-includes/js/customize-preview.js#L69-L73
+	 * This fixes Core ticket {@link https://core.trac.wordpress.org/ticket/20714|#20714: Theme customizer: Impossible to preview a search results page}
+	 * Implements todo in {@link https://github.com/xwp/wordpress-develop/blob/4.5.3/src/wp-includes/js/customize-preview.js#L69-L73}
+	 *
+	 * @returns {void}
 	 */
 	component.handleFormSubmissions = function handleFormSubmissions() {
 		$( function() {
@@ -170,11 +173,14 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 
 			/*
 			 * If the default wasn't prevented already (in which case the form
-			 * submission is already being handled by JS), and if the method is
-			 * GET and its action points to a URL on this site, then take the
-			 * serialized form data and add it as a query string to the action
-			 * URL and send this in a url message to the Customizer pane so that
-			 * it will be loaded.
+			 * submission is already being handled by JS), and if it has a GET
+			 * request method, then take the serialized form data and add it as
+			 * a query string to the action URL and send this in a url message
+			 * to the Customizer pane so that it will be loaded. If the form's
+			 * action points to a non-previewable URL, the the Customizer pane's
+			 * previewUrl setter will reject it so that the form submission is
+			 * a no-op, which is the same behavior as when clicking a link to an
+			 * external site in the preview.
 			 */
 			if ( ! event.isDefaultPrevented() && 'GET' === this.method.toUpperCase() ) {
 				urlParser = document.createElement( 'a' );
@@ -183,7 +189,6 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 					urlParser.search += '&';
 				}
 				urlParser.search += $( this ).serialize();
-
 				api.preview.send( 'url', urlParser.href );
 			}
 

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -683,6 +683,7 @@ class Customize_Snapshot_Manager {
 
 		$handle = 'customize-snapshots-preview';
 		wp_enqueue_script( $handle );
+		wp_enqueue_style( $handle );
 
 		$exports = array(
 			'home_url' => wp_parse_url( home_url( '/' ) ),

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -96,5 +96,10 @@ class Plugin extends Plugin_Base {
 		$src = $this->dir_url . 'css/customize-snapshots' . $min . '.css';
 		$deps = array( 'wp-jquery-ui-dialog' );
 		$wp_styles->add( $handle, $src, $deps );
+
+		$handle = 'customize-snapshots-preview';
+		$src = $this->dir_url . 'css/customize-snapshots-preview' . $min . '.css';
+		$deps = array( 'customize-preview' );
+		$wp_styles->add( $handle, $src, $deps );
 	}
 }


### PR DESCRIPTION
In the Customizer preview, the changes here allow for forms with a `GET` request method to be submitted and for the resultant URL to be loaded in the preview. This fixes a Core enhancement  [#20714](https://core.trac.wordpress.org/ticket/20714): Theme customizer: Impossible to preview a search results page. The reason for disallowing `POST` requests is that they normally should entail mutating the server state which should be forbidden when using the Customizer, as all changes should flow through Customizer settings and only affected once hitting “Save & Publish”. If a form has a `POST` request method then any submit buttons will have a `not-allowed` cursor.

Likewise, when previewing the Customizer state on the _frontend_ (when the `customize_snapshot_uuid` query param is present), all forms that have `action` URLs pointing to the WP instance in the current document will be amended to have a `customize_snapshot_uuid` named `input` element. In this way, any form submissions done on the frontend will also result in the previewed Customizer state being persisted in the response.
