### PR TITLE
Prevent enqueueing frontend JS in the customizer prevew

### DIFF
--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -725,7 +725,7 @@ class Customize_Snapshot_Manager {
 	 * Enqueue Customizer frontend scripts.
 	 */
 	public function enqueue_frontend_scripts() {
-		if ( ! $this->snapshot ) {
+		if ( ! $this->snapshot || is_customize_preview() ) {
 			return;
 		}
 		$handle = 'customize-snapshots-frontend';


### PR DESCRIPTION
This was erroneously causing the customize_snapshot_uuid param to get injected into links in the preview.
