### PR TITLE
Introduce REST API previewing

### DIFF
--- a/css/customize-snapshots.css
+++ b/css/customize-snapshots.css
@@ -201,3 +201,54 @@
 .select2-container {
 	z-index: 500100 !important;
 }
+
+/*
+ * REST API Previewing.
+ */
+#rest-api-preview {
+	position:absolute;
+	height: 0;
+	left: 0;
+	right: 0;
+	bottom: -46px;
+	background: #eee;
+	border-top: 1px solid #ddd;
+	line-height: 45px;
+	padding-left: 10px;
+
+	-webkit-transition-property: top, height, bottom;
+	transition-property: top, height, bottom;
+	-webkit-transition-duration: 0.2s;
+	transition-duration: 0.2s;
+}
+body.rest-api-preview-enabled #rest-api-preview {
+	height: 45px;
+	bottom: 0;
+}
+
+body.rest-api-preview-enabled #customize-preview {
+	bottom: 46px;
+}
+
+#rest-api-preview .rest-api-response {
+	display: none;
+}
+
+#rest-api-preview .rest-api-url-label,
+#rest-api-preview .rest-api-url-link,
+#rest-api-preview .rest-api-log-response {
+	vertical-align: middle;
+}
+#rest-api-preview .rest-api-log-response code {
+	background: transparent;
+}
+
+body.rest-api-preview-enabled.rest-api-preview-expanded #rest-api-preview {
+	top: 0;
+	bottom: 0;
+	height: auto;
+}
+body.rest-api-preview-enabled.rest-api-preview-expanded #rest-api-preview .rest-api-response {
+	display: block;
+	overflow: auto;
+}

--- a/js/customize-snapshots-preview.js
+++ b/js/customize-snapshots-preview.js
@@ -26,7 +26,8 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 				host: '',
 				path: ''
 			},
-			initial_dirty_settings: []
+			initial_dirty_settings: [],
+			queried_object_rest_api_url: null
 		}
 	};
 
@@ -42,6 +43,7 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 
 		component.injectSnapshotIntoAjaxRequests();
 		component.handleFormSubmissions();
+		component.setupSendingQueriedObjectRestApiUrl();
 	};
 
 	/**
@@ -195,6 +197,19 @@ var CustomizeSnapshotsPreview = (function( api, $ ) {
 			// Now preventDefault as is done on the normal submit.preview handler in customize-preview.js.
 			event.preventDefault();
 		});
+	};
+
+	/**
+	 * Setup the sending of the queried object REST API URL to the pane.
+	 *
+	 * @returns {void}
+	 */
+	component.setupSendingQueriedObjectRestApiUrl = function setupSendingQueriedObjectRestApiUrl() {
+		api.bind( 'preview-ready', function onPreviewReady() {
+			api.preview.bind( 'active', function onPaneActive() {
+				api.preview.send( 'queried-object-rest-api-url', component.data.queried_object_rest_api_url );
+			} );
+		} );
 	};
 
 	return component;

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -1,4 +1,5 @@
-/* global jQuery, _customizeSnapshots */
+/* global jQuery, _customizeSnapshots, console */
+/* eslint no-magic-numbers: [ "error", { "ignore": [1] } ] */
 
 ( function( api, $ ) {
 	'use strict';
@@ -82,6 +83,8 @@
 				api.state( 'saved' ).set( false );
 				component.resetSavedStateQuietly();
 			}
+
+			component.setupPreviewingRestApi();
 
 			api.trigger( 'snapshots-ready', component );
 		} );
@@ -638,6 +641,80 @@
 				modal: true
 			} );
 		} );
+	};
+
+	/**
+	 * Listen for queried object REST API URL.
+	 *
+	 * @returns {void}
+	 */
+	component.setupPreviewingRestApi = function setupPreviewingRestApi() {
+		var restApiPreviewWait = 250;
+		component.previewRestApiUrl = new api.Value( '' );
+
+		api.previewer.bind( 'queried-object-rest-api-url', function( restUrl ) {
+			component.previewRestApiUrl.set( restUrl || '' );
+		} );
+
+		component.previewRestApiContainer = $( $.trim( wp.template( 'customize-rest-api-preview' )() ) );
+		component.previewRestApiContainer.insertAfter( '#customize-preview' );
+
+		component.previewRestApiContainer.find( '.rest-api-log-response' ).on( 'click', function() {
+			var requestUrl = component.previewRestApiContainer.find( '.rest-api-url-link' ).prop( 'href' );
+			if ( ! requestUrl ) {
+				return;
+			}
+			component.previewRestApiRequest = $.getJSON( requestUrl );
+			component.previewRestApiRequest.done( function( data ) {
+				console.log( '[GET %s] %O', requestUrl, data );
+			} );
+		} );
+
+		component.updateRestApiUrlPreview = _.debounce( component.updateRestApiUrlPreview, restApiPreviewWait );
+		component.previewRestApiUrl.bind( component.updateRestApiUrlPreview );
+		api.state.bind( 'change', component.updateRestApiUrlPreview );
+		api.bind( 'change', component.updateRestApiUrlPreview );
+	};
+
+	/**
+	 * Update queried object REST API URL preview.
+	 *
+	 * @returns {void}
+	 */
+	component.updateRestApiUrlPreview = function updateRestApiUrlPreview() {
+		var restApiUrl, urlParser, isSavedState, requestUrl;
+
+		if ( component.previewRestApiRequest ) {
+			component.previewRestApiRequest.abort();
+			component.previewRestApiRequest = null;
+		}
+
+		restApiUrl = component.previewRestApiUrl.get();
+		isSavedState = api.state( 'saved' ).get() || api.state( 'snapshot-saved' ).get();
+		urlParser = document.createElement( 'a' );
+
+		urlParser.href = restApiUrl;
+		if ( urlParser.search.length > 1 ) {
+			urlParser.search += '&';
+		}
+		urlParser.search += 'context=edit';
+
+		if ( api.state( 'snapshot-exists' ).get() && component.data.uuid ) {
+			urlParser.search += '&customize_snapshot_uuid=' + component.data.uuid;
+		}
+		restApiUrl = urlParser.href;
+
+		urlParser.search += '&_wpnonce=' + api.settings.nonce['rest-api'];
+		requestUrl = urlParser.href;
+
+		if ( restApiUrl && isSavedState ) {
+			component.previewRestApiContainer.find( '.rest-api-url-link' ).text( restApiUrl ).prop( 'href', requestUrl );
+			$( document.body ).addClass( 'rest-api-preview-enabled' );
+		} else {
+			$( document.body ).removeClass( 'rest-api-preview-enabled' );
+		}
+
+		// http://src.wordpress-develop.dev/wp-json/wp/v2/posts/?context=edit&_wpnonce=9dcb874897
 	};
 
 	/**

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -713,12 +713,66 @@ class Customize_Snapshot_Manager {
 			'rest_api_url' => wp_parse_url( rest_url( '/' ) ),
 			'admin_ajax_url' => wp_parse_url( admin_url( 'admin-ajax.php' ) ),
 			'initial_dirty_settings' => array_keys( $wp_customize->unsanitized_post_values() ),
+			'queried_object_rest_api_url' => rest_url( $this->get_queried_object_rest_api_path() ),
 		);
 		wp_add_inline_script(
 			$handle,
-			sprintf( 'CustomizeSnapshotsPreview.init( %s )', wp_json_encode( $exports ) ),
+			sprintf( 'CustomizeSnapshotsPreview.init( %s );', wp_json_encode( $exports ) ),
 			'after'
 		);
+	}
+
+	/**
+	 * Get REST API endpoint for queried object.
+	 *
+	 * @return string|null
+	 */
+	public function get_queried_object_rest_api_path() {
+
+		$namespace = 'wp/v2'; // Assumed because WP_REST_Controller::$namespace is protected.
+
+		$leaf = '/';
+
+		$rest_api_path = null;
+		$rest_base = null;
+
+		$queried_object = get_queried_object();
+		if ( $queried_object instanceof \WP_Post_Type ) {
+			if ( ! empty( $queried_object->show_in_rest ) ) {
+				$rest_base = isset( $queried_object->rest_base ) ? $queried_object->rest_base : $queried_object->name;
+			}
+		} elseif ( $queried_object instanceof \WP_Post ) {
+			$post_type_object = get_post_type_object( $queried_object->post_type );
+			if ( ! empty( $post_type_object->show_in_rest ) ) {
+				$rest_base = isset( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
+				$leaf .= $queried_object->ID . '/';
+			}
+		} elseif ( $queried_object instanceof \WP_Term ) {
+			$taxonomy_object = get_taxonomy( $queried_object->taxonomy );
+			if ( ! empty( $taxonomy_object->show_in_rest ) ) {
+				$rest_base = isset( $taxonomy_object->rest_base ) ? $taxonomy_object->rest_base : $taxonomy_object->name;
+				$leaf .= $queried_object->term_id . '/';
+			}
+		} elseif ( is_home() ) {
+			$post_type_object = get_post_type_object( 'post' );
+			if ( ! empty( $post_type_object->show_in_rest ) ) {
+				$rest_base = isset( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
+			}
+		}
+
+		if ( $rest_base ) {
+			$rest_api_path = $namespace . '/' . $rest_base . $leaf;
+		}
+
+		/**
+		 * Filters the REST API path for the current queried object.
+		 *
+		 * @param string|null $rest_api_path REST API Path, null if none was auto-detected.
+		 * @param \WP_Post_Type|\WP_Term|\WP_Post|null $queried_object Queried object.
+		 */
+		$rest_api_path = apply_filters( 'customize_snapshots_queried_object_rest_api_path', $rest_api_path, $queried_object );
+
+		return $rest_api_path;
 	}
 
 	/**
@@ -746,13 +800,14 @@ class Customize_Snapshot_Manager {
 	}
 
 	/**
-	 * Include the snapshot nonce in the Customizer nonces.
+	 * Include the snapshot and REST API nonce in the Customizer nonces.
 	 *
 	 * @param array $nonces Nonces.
 	 * @return array Nonces.
 	 */
 	public function filter_customize_refresh_nonces( $nonces ) {
 		$nonces['snapshot'] = wp_create_nonce( self::AJAX_ACTION );
+		$nonces['rest-api'] = wp_create_nonce( 'wp_rest' );
 		return $nonces;
 	}
 
@@ -1399,6 +1454,19 @@ class Customize_Snapshot_Manager {
 
 		$description = __( 'Schedule your changes to publish (go live) at a future date.', 'customize-snapshots' );
 		?>
+		<script type="text/html" id="tmpl-customize-rest-api-preview">
+			<div id="rest-api-preview">
+				<div class="rest-api-url-bar">
+					<button class="rest-api-log-response button button-secondary" type="button">
+						<code>console.log()</code>
+					</button>
+					<span class="rest-api-url-label"><?php esc_html_e( 'REST API URL:', 'customize-snapshots' ) ?></span>
+					<a class="rest-api-url-link" href="" target="_blank"></a>
+				</div>
+				<pre class="rest-api-response"></pre>
+			</div>
+		</script>
+
 		<script type="text/html" id="tmpl-snapshot-preview-link">
 			<a href="#" target="frontend-preview" id="snapshot-preview-link" class="dashicons dashicons-welcome-view-site" title="<?php esc_attr_e( 'View on frontend', 'customize-snapshots' ) ?>">
 				<span class="screen-reader-text"><?php esc_html_e( 'View on frontend', 'customize-snapshots' ) ?></span>

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -708,12 +708,13 @@ class Customize_Snapshot_Manager {
 		wp_enqueue_script( $handle );
 		wp_enqueue_style( $handle );
 
+		$rest_api_path = $this->get_queried_object_rest_api_path();
 		$exports = array(
 			'home_url' => wp_parse_url( home_url( '/' ) ),
 			'rest_api_url' => wp_parse_url( rest_url( '/' ) ),
 			'admin_ajax_url' => wp_parse_url( admin_url( 'admin-ajax.php' ) ),
 			'initial_dirty_settings' => array_keys( $wp_customize->unsanitized_post_values() ),
-			'queried_object_rest_api_url' => rest_url( $this->get_queried_object_rest_api_path() ),
+			'queried_object_rest_api_url' => $rest_api_path ? rest_url( $rest_api_path ) : null,
 		);
 		wp_add_inline_script(
 			$handle,


### PR DESCRIPTION
A new bar appears at the bottom of the customizer that includes the URL for REST API request for the queried object. The URL includes the snapshot's UUID when a snapshot exists. The bar is hidden when the snapshot is not saved or when the overall customizer state is not saved, since REST API previewing requires the customizer state to be written to the DB. A button is also shown for making the API request and logging the output to the console, aside from the link to the REST API endpoint URL link that opens in a new window as well.
- [ ] Allow the bar to be expanded with the REST API response overlaying the customizer preview, where each snapshot update could show the changes in a pretty-printed JSON element.
- [ ] Add unit tests.
- [ ] Allow for multiple REST API endpoint URLs to be surfaced from the preview instead of just the queried object?

<img width="1437" alt="rest-api-previewing" src="https://cloud.githubusercontent.com/assets/134745/17913560/d8d1f5b4-694f-11e6-9c62-b99157315bcd.png">
