### PR TITLE
Issue #17 : Enable deleting settings in snapshot wp-admin/post page.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ node_js:
     - stable
 
 env:
-    - WP_VERSION=trunk WP_MULTISITE=0
+    - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
 
 install:

--- a/css/customize-snapshots-admin.css
+++ b/css/customize-snapshots-admin.css
@@ -1,0 +1,12 @@
+details.cs-removed summary::-webkit-details-marker {
+	display:none;
+}
+details:not(.cs-removed) .cs-toggle-action {
+	color: #a00
+}
+details:not(.cs-removed) .cs-toggle-action:hover {
+	color: #f00
+}
+details .cs-toggle-action {
+	float: right;
+}

--- a/css/customize-snapshots-admin.css
+++ b/css/customize-snapshots-admin.css
@@ -1,12 +1,12 @@
-details.cs-removed summary::-webkit-details-marker {
-	display:none;
+details.snapshot-setting-removed summary {
+	text-decoration: line-through;
 }
-details:not(.cs-removed) .cs-toggle-action {
+details:not(.snapshot-setting-removed) .snapshot-toggle-setting-removal {
 	color: #a00
 }
-details:not(.cs-removed) .cs-toggle-action:hover {
+details:not(.snapshot-setting-removed) .snapshot-toggle-setting-removal:hover {
 	color: #f00
 }
-details .cs-toggle-action {
+details .snapshot-toggle-setting-removal {
 	float: right;
 }

--- a/js/customize-snapshots-admin.js
+++ b/js/customize-snapshots-admin.js
@@ -2,18 +2,16 @@
 	'use strict';
 
 	$( function() {
-		var component, linkSelector, linkText, linkActions, dataSlug, inputName;
+		var component, $linkToRemoveOrRestore, linkActions, dataSlug, inputName;
 
 		component = {};
-		linkSelector = '.snapshot-toggle-setting-removal';
-		linkText = [ 'Remove setting', 'Restore setting' ];
+		$linkToRemoveOrRestore = $( '.snapshot-toggle-setting-removal' );
 		linkActions = [ 'remove', 'restore' ];
 		dataSlug = 'cs-action';
 		inputName = 'customize_snapshot_remove_settings[]';
 
 		component.initializeLink = function() {
-			$( linkSelector ).text( linkText[ 0 ] )
-				.data( dataSlug, linkActions[ 0 ] );
+			$linkToRemoveOrRestore.data( dataSlug, linkActions[ 0 ] );
 		};
 
 		component.initializeLink();
@@ -35,9 +33,9 @@
 			$settingDisplay = component.getSettingDisplay( $link );
 			settingId = component.getSettingId( $link );
 
-			$link.text( linkText[ 1 ] )
-				.data( dataSlug, linkActions[ 1 ] )
+			$link.data( dataSlug, linkActions[ 1 ] )
 				.after( component.constructHiddenInputWithValue( settingId ) );
+			component.changeLinkText( $link );
 			$settingDisplay.removeAttr( 'open' )
 				.addClass( 'snapshot-setting-removed' );
 		};
@@ -58,13 +56,22 @@
 			.val( settingId );
 		};
 
+		component.changeLinkText = function( $link ) {
+			var oldLinkText, newLinkText;
+			oldLinkText = $link.text();
+			newLinkText = $link.data( 'text-restore' );
+
+			$link.data( 'text-restore', oldLinkText )
+				.text( newLinkText );
+		};
+
 		component.showSettingAndChangeLinkText = function( $link ) {
 			var $settingDisplay, settingId;
 			$settingDisplay = component.getSettingDisplay( $link );
 			settingId = component.getSettingId( $link );
 
-			$link.text( linkText[ 0 ] )
-				.data( dataSlug, linkActions[ 0 ] );
+			$link.data( dataSlug, linkActions[ 0 ] );
+			component.changeLinkText( $link );
 			component.removeHiddenInputWithValue( settingId );
 			$settingDisplay.removeClass( 'snapshot-setting-removed' );
 		};
@@ -73,7 +80,7 @@
 			$( 'input[name="' + inputName + '"][value="' + settingId + '"]' ).remove();
 		};
 
-		$( linkSelector ).on( 'click', function( event ) {
+		$linkToRemoveOrRestore.on( 'click', function( event ) {
 			var $clickedLink = $( this );
 
 			event.preventDefault();

--- a/js/customize-snapshots-admin.js
+++ b/js/customize-snapshots-admin.js
@@ -53,11 +53,11 @@
 			this.showSettingAndChangeLinkText = function() {
 				$clickedLink.text( linkText[ 0 ] )
 					.data( dataSlug, linkActions[ 0 ] );
-				this.removeHiddenInputWithValue( settingId );
+				this.removeHiddenInputWithValue();
 				$settingDisplay.removeClass( 'cs-removed' );
 			};
 
-			this.removeHiddenInputWithValue = function( settingId ) {
+			this.removeHiddenInputWithValue = function() {
 				$( 'input[value="' + settingId + '"]' ).remove();
 			};
 

--- a/js/customize-snapshots-admin.js
+++ b/js/customize-snapshots-admin.js
@@ -1,4 +1,5 @@
 ( function( $ ) {
+	'use strict';
 
 	$( function() {
 		var $link, linkText, linkActions, dataSlug, initializeLink;
@@ -26,18 +27,18 @@
 			settingId = $( this ).attr( 'id' );
 
 			this.isLinkSetToRemoveSetting = function() {
-				return ( linkActions[ 0 ] === clickedLinkAction );
+				return linkActions[ 0 ] === clickedLinkAction;
 			};
 
 			this.hideSettingAndChangeLinkText = function() {
 				$clickedLink.text( linkText[ 1 ] )
 					.data( dataSlug, linkActions[ 1 ] )
-					.after( this.constructHiddenInputWithValue( settingId ) );
+					.after( this.constructHiddenInputWithValue() );
 				$settingDisplay.removeAttr( 'open' )
 					.addClass( 'cs-removed' );
 			};
 
-			this.constructHiddenInputWithValue = function( settingId ) {
+			this.constructHiddenInputWithValue = function() {
 				return $( '<input>' ).attr( {
 					'name': 'customize_snapshot_remove_settings[]',
 					'type': 'hidden'
@@ -46,7 +47,7 @@
 			};
 
 			this.isLinkSetToRestoreSetting = function() {
-				return ( linkActions[ 1 ] === clickedLinkAction );
+				return linkActions[ 1 ] === clickedLinkAction;
 			};
 
 			this.showSettingAndChangeLinkText = function() {
@@ -69,4 +70,4 @@
 		} );
 
 	} );
-}( jQuery ) );
+} )( jQuery );

--- a/js/customize-snapshots-admin.js
+++ b/js/customize-snapshots-admin.js
@@ -2,71 +2,87 @@
 	'use strict';
 
 	$( function() {
-		var $link, linkText, linkActions, dataSlug, initializeLink;
+		var component, linkSelector, linkText, linkActions, dataSlug, inputName;
 
-		$link = $( '.snapshot-toggle-setting-removal' );
+		component = {};
+		linkSelector = '.snapshot-toggle-setting-removal';
 		linkText = [ 'Remove setting', 'Restore setting' ];
 		linkActions = [ 'remove', 'restore' ];
 		dataSlug = 'cs-action';
+		inputName = 'customize_snapshot_remove_settings[]';
 
-		initializeLink = function() {
-			$link.text( linkText[ 0 ] )
+		component.initializeLink = function() {
+			$( linkSelector ).text( linkText[ 0 ] )
 				.data( dataSlug, linkActions[ 0 ] );
 		};
 
-		initializeLink();
+		component.initializeLink();
 
-		$link.on( 'click', function( event ) {
-			var $clickedLink, $settingDisplay, clickedLinkAction, settingId;
+		component.isLinkSetToRemoveSetting = function( $link ) {
+			return linkActions[ 0 ] === component.getClickedLinkAction( $link );
+		};
+
+		component.isLinkSetToRestoreSetting = function( $link ) {
+			return linkActions[ 1 ] === component.getClickedLinkAction( $link );
+		};
+
+		component.getClickedLinkAction = function( $link ) {
+			return $link.data( dataSlug );
+		};
+
+		component.hideSettingAndChangeLinkText = function( $link ) {
+			var $settingDisplay, settingId;
+			$settingDisplay = component.getSettingDisplay( $link );
+			settingId = component.getSettingId( $link );
+
+			$link.text( linkText[ 1 ] )
+				.data( dataSlug, linkActions[ 1 ] )
+				.after( component.constructHiddenInputWithValue( settingId ) );
+			$settingDisplay.removeAttr( 'open' )
+				.addClass( 'snapshot-setting-removed' );
+		};
+
+		component.getSettingDisplay = function( $link ) {
+			return $link.parents( 'details' );
+		};
+
+		component.getSettingId = function( $link ) {
+			return $link.attr( 'id' );
+		};
+
+		component.constructHiddenInputWithValue = function( settingId ) {
+			return $( '<input>' ).attr( {
+				'name': inputName,
+				'type': 'hidden'
+			} )
+			.val( settingId );
+		};
+
+		component.showSettingAndChangeLinkText = function( $link ) {
+			var $settingDisplay, settingId;
+			$settingDisplay = component.getSettingDisplay( $link );
+			settingId = component.getSettingId( $link );
+
+			$link.text( linkText[ 0 ] )
+				.data( dataSlug, linkActions[ 0 ] );
+			component.removeHiddenInputWithValue( settingId );
+			$settingDisplay.removeClass( 'snapshot-setting-removed' );
+		};
+
+		component.removeHiddenInputWithValue = function( settingId ) {
+			$( 'input[name="' + inputName + '"][value="' + settingId + '"]' ).remove();
+		};
+
+		$( linkSelector ).on( 'click', function( event ) {
+			var $clickedLink = $( this );
 
 			event.preventDefault();
 
-			$clickedLink = $( this );
-			$settingDisplay = $( this ).parents( 'details' );
-			clickedLinkAction = $( this ).data( dataSlug );
-			settingId = $( this ).attr( 'id' );
-
-			this.isLinkSetToRemoveSetting = function() {
-				return linkActions[ 0 ] === clickedLinkAction;
-			};
-
-			this.hideSettingAndChangeLinkText = function() {
-				$clickedLink.text( linkText[ 1 ] )
-					.data( dataSlug, linkActions[ 1 ] )
-					.after( this.constructHiddenInputWithValue() );
-				$settingDisplay.removeAttr( 'open' )
-					.addClass( 'snapshot-setting-removed' );
-			};
-
-			this.constructHiddenInputWithValue = function() {
-				return $( '<input>' ).attr( {
-					'name': 'customize_snapshot_remove_settings[]',
-					'type': 'hidden'
-				})
-				.val( settingId );
-			};
-
-			this.isLinkSetToRestoreSetting = function() {
-				return linkActions[ 1 ] === clickedLinkAction;
-			};
-
-			this.showSettingAndChangeLinkText = function() {
-				$clickedLink.text( linkText[ 0 ] )
-					.data( dataSlug, linkActions[ 0 ] );
-				this.removeHiddenInputWithValue();
-				$settingDisplay.removeClass( 'snapshot-setting-removed' );
-			};
-
-			this.removeHiddenInputWithValue = function() {
-				$( 'input[value="' + settingId + '"]' ).remove();
-			};
-
-			if ( this.isLinkSetToRemoveSetting() ) {
-				this.hideSettingAndChangeLinkText();
-			} else if ( this.isLinkSetToRestoreSetting() ) {
-				this.showSettingAndChangeLinkText();
+			if ( component.isLinkSetToRemoveSetting( $clickedLink ) ) {
+				component.hideSettingAndChangeLinkText( $clickedLink );
+			} else if ( component.isLinkSetToRestoreSetting( $clickedLink ) ) {
+				component.showSettingAndChangeLinkText( $clickedLink );
 			}
-
 		} );
 
 	} );

--- a/js/customize-snapshots-admin.js
+++ b/js/customize-snapshots-admin.js
@@ -4,7 +4,7 @@
 	$( function() {
 		var $link, linkText, linkActions, dataSlug, initializeLink;
 
-		$link = $( '.cs-toggle-action' );
+		$link = $( '.snapshot-toggle-setting-removal' );
 		linkText = [ 'Remove setting', 'Restore setting' ];
 		linkActions = [ 'remove', 'restore' ];
 		dataSlug = 'cs-action';
@@ -35,7 +35,7 @@
 					.data( dataSlug, linkActions[ 1 ] )
 					.after( this.constructHiddenInputWithValue() );
 				$settingDisplay.removeAttr( 'open' )
-					.addClass( 'cs-removed' );
+					.addClass( 'snapshot-setting-removed' );
 			};
 
 			this.constructHiddenInputWithValue = function() {
@@ -54,7 +54,7 @@
 				$clickedLink.text( linkText[ 0 ] )
 					.data( dataSlug, linkActions[ 0 ] );
 				this.removeHiddenInputWithValue();
-				$settingDisplay.removeClass( 'cs-removed' );
+				$settingDisplay.removeClass( 'snapshot-setting-removed' );
 			};
 
 			this.removeHiddenInputWithValue = function() {

--- a/js/customize-snapshots-admin.js
+++ b/js/customize-snapshots-admin.js
@@ -1,0 +1,72 @@
+( function( $ ) {
+
+	$( function() {
+		var $link, linkText, linkActions, dataSlug, initializeLink;
+
+		$link = $( '.cs-toggle-action' );
+		linkText = [ 'Remove setting', 'Restore setting' ];
+		linkActions = [ 'remove', 'restore' ];
+		dataSlug = 'cs-action';
+
+		initializeLink = function() {
+			$link.text( linkText[ 0 ] )
+				.data( dataSlug, linkActions[ 0 ] );
+		};
+
+		initializeLink();
+
+		$link.on( 'click', function( event ) {
+			var $clickedLink, $settingDisplay, clickedLinkAction, settingId;
+
+			event.preventDefault();
+
+			$clickedLink = $( this );
+			$settingDisplay = $( this ).parents( 'details' );
+			clickedLinkAction = $( this ).data( dataSlug );
+			settingId = $( this ).attr( 'id' );
+
+			this.isLinkSetToRemoveSetting = function() {
+				return ( linkActions[ 0 ] === clickedLinkAction );
+			};
+
+			this.hideSettingAndChangeLinkText = function() {
+				$clickedLink.text( linkText[ 1 ] )
+					.data( dataSlug, linkActions[ 1 ] )
+					.after( this.constructHiddenInputWithValue( settingId ) );
+				$settingDisplay.removeAttr( 'open' )
+					.addClass( 'cs-removed' );
+			};
+
+			this.constructHiddenInputWithValue = function( settingId ) {
+				return $( '<input>' ).attr( {
+					'name': 'customize_snapshot_remove_settings[]',
+					'type': 'hidden'
+				})
+				.val( settingId );
+			};
+
+			this.isLinkSetToRestoreSetting = function() {
+				return ( linkActions[ 1 ] === clickedLinkAction );
+			};
+
+			this.showSettingAndChangeLinkText = function() {
+				$clickedLink.text( linkText[ 0 ] )
+					.data( dataSlug, linkActions[ 0 ] );
+				this.removeHiddenInputWithValue( settingId );
+				$settingDisplay.removeClass( 'cs-removed' );
+			};
+
+			this.removeHiddenInputWithValue = function( settingId ) {
+				$( 'input[value="' + settingId + '"]' ).remove();
+			};
+
+			if ( this.isLinkSetToRemoveSetting() ) {
+				this.hideSettingAndChangeLinkText();
+			} else if ( this.isLinkSetToRestoreSetting() ) {
+				this.showSettingAndChangeLinkText();
+			}
+
+		} );
+
+	} );
+}( jQuery ) );

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -751,11 +751,13 @@ class Customize_Snapshot_Manager {
 	 *
 	 * These files control the behavior and styling of links to remove settings.
 	 * Published snapshots can't be edited, so these files are not needed on those pages.
+	 *
+	 * @param String $hook Current page in admin.
 	 */
-	public function enqueue_admin_scripts() {
+	public function enqueue_admin_scripts( $hook ) {
 		global $post;
 		$handle = 'customize-snapshots-admin';
-		if ( isset( $post->post_type ) && ( Post_Type::SLUG === $post->post_type ) && ( 'publish' !== $post->post_status ) ) {
+		if ( ( 'post.php' === $hook ) && isset( $post->post_type ) && ( Post_Type::SLUG === $post->post_type ) && ( 'publish' !== $post->post_status ) ) {
 			wp_enqueue_script( $handle );
 			wp_enqueue_style( $handle );
 		}

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -102,6 +102,7 @@ class Customize_Snapshot_Manager {
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_controls_scripts' ) );
 		add_action( 'customize_preview_init', array( $this, 'customize_preview_init' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 
 		add_action( 'customize_controls_init', array( $this, 'add_snapshot_uuid_to_return_url' ) );
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'render_templates' ) );
@@ -742,6 +743,21 @@ class Customize_Snapshot_Manager {
 			sprintf( 'CustomizeSnapshotsFrontend.init( %s )', wp_json_encode( $exports ) ),
 			'after'
 		);
+	}
+
+	/**
+	 * Enqueue admin scripts.
+	 *
+	 * These files control the behavior and styling of links to remove settings.
+	 * Published snapshots can't be edited, so these files are not needed on those pages.
+	 */
+	public function enqueue_admin_scripts() {
+		global $post;
+		$handle = 'customize-snapshots-admin';
+		if ( isset( $post->post_type ) && ( Post_Type::SLUG === $post->post_type ) && ( 'publish' !== $post->post_status ) ) {
+			wp_enqueue_script( $handle );
+			wp_enqueue_style( $handle );
+		}
 	}
 
 	/**

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -82,6 +82,11 @@ class Plugin extends Plugin_Base {
 		$src = $this->dir_url . 'js/customize-snapshots-frontend' . $min . '.js';
 		$deps = array( 'jquery', 'underscore' );
 		$wp_scripts->add( $handle, $src, $deps );
+
+		$handle = 'customize-snapshots-admin';
+		$src = $this->dir_url . 'js/customize-snapshots-admin' . $min . '.js';
+		$deps = array( 'jquery' );
+		$wp_scripts->add( $handle, $src, $deps );
 	}
 
 	/**
@@ -103,5 +108,9 @@ class Plugin extends Plugin_Base {
 		$src = $this->dir_url . 'css/customize-snapshots-preview' . $min . '.css';
 		$deps = array( 'customize-preview' );
 		$wp_styles->add( $handle, $src, $deps );
+
+		$handle = 'customize-snapshots-admin';
+		$src = $this->dir_url . 'css/customize-snapshots-admin' . $min . '.css';
+		$wp_styles->add( $handle, $src );
 	}
 }

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -114,6 +114,7 @@ class Post_Type {
 		add_filter( 'display_post_states', array( $this, 'display_post_states' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'show_publish_error_admin_notice' ) );
 		add_action( 'post_submitbox_minor_actions', array( $this, 'hide_disabled_publishing_actions' ) );
+		add_filter( 'content_save_pre', array( $this, 'filter_out_settings_if_removed_in_metabox' ), 10 );
 		add_action( 'admin_print_scripts-revision.php', array( $this, 'disable_revision_ui_for_published_posts' ) );
 	}
 
@@ -351,6 +352,7 @@ class Post_Type {
 		echo '<hr>';
 
 		ksort( $snapshot_content );
+		wp_nonce_field( static::SLUG . '_settings', static::SLUG );
 		echo '<ul id="snapshot-settings">';
 		foreach ( $snapshot_content as $setting_id => $setting_params ) {
 			if ( ! isset( $setting_params['value'] ) && ! isset( $setting_params['publish_error'] ) ) {
@@ -360,6 +362,7 @@ class Post_Type {
 			echo '<li>';
 			echo '<details open>';
 			echo '<summary><code>' . esc_html( $setting_id ) . '</code> ';
+			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" class="cs-toggle-action remove"></a>';
 
 			// Show error message when there was a publishing error.
 			if ( isset( $setting_params['publish_error'] ) ) {
@@ -674,5 +677,52 @@ class Post_Type {
 			}
 		</style>
 		<?php
+	}
+
+	/**
+	 * Filter settings out of post content, if they were removed in the meta box.
+	 *
+	 * In each snapshot's edit page, there are JavaScript-controlled links to remove each setting.
+	 * On clicking a setting, the JS sets a hidden input field with that setting's ID.
+	 * And these settings appear in $_REQUEST as the array 'customize_snapshot_remove_settings.'
+	 * So look for these removed settings in that array, on saving.
+	 * And possibly filter out those settings from the post content.
+	 *
+	 * @param String $content Post content to filter.
+	 * @return String $content Post content, possibly filtered.
+	 */
+	public function filter_out_settings_if_removed_in_metabox( $content ) {
+		global $post;
+		$key_for_settings = static::SLUG . '_remove_settings';
+		$post_type_object = get_post_type_object( static::SLUG );
+
+		$should_filter_content = (
+			( 'publish' !== $post->post_status )
+			&&
+			current_user_can( $post_type_object->cap->edit_post, $post->ID )
+			&&
+			( static::SLUG === $post->post_type )
+			&&
+			! empty( $_REQUEST[ $key_for_settings ] )
+			&&
+			isset( $_REQUEST[ static::SLUG ] )
+			&&
+			wp_verify_nonce( $_REQUEST[ static::SLUG ], static::SLUG . '_settings' )
+			&&
+			! ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		);
+
+		if ( ! $should_filter_content ) {
+			return $content;
+		}
+
+		$setting_ids_to_unset = $_REQUEST[ $key_for_settings ];
+		$data = json_decode( $post->post_content );
+		foreach ( $setting_ids_to_unset as $setting_id ) {
+			unset( $data->{ $setting_id } );
+		}
+		$content = Customize_Snapshot_Manager::encode_json( $data );
+
+		return $content;
 	}
 }

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -719,7 +719,7 @@ class Post_Type {
 		}
 
 		$setting_ids_to_unset = $_REQUEST[ $key_for_settings ];
-		$data = json_decode( $post->post_content, true );
+		$data = json_decode( wp_unslash( $content ), true );
 		foreach ( $setting_ids_to_unset as $setting_id ) {
 			unset( $data[ $setting_id ] );
 		}

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -372,7 +372,7 @@ class Post_Type {
 			echo '<li>';
 			echo '<details open>';
 			echo '<summary><code>' . esc_html( $setting_id ) . '</code> ';
-			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" data-text-restore="' . esc_attr( 'Restore setting', 'customize-snapshots' ) . '" class="snapshot-toggle-setting-removal remove">' . esc_html( 'Remove setting', 'customize-snapshots' ) . '</a>';
+			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" data-text-restore="' . esc_attr__( 'Restore setting', 'customize-snapshots' ) . '" class="snapshot-toggle-setting-removal remove">' . esc_html__( 'Remove setting', 'customize-snapshots' ) . '</a>';
 
 			// Show error message when there was a publishing error.
 			if ( isset( $setting_params['publish_error'] ) ) {

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -697,6 +697,8 @@ class Post_Type {
 		$post_type_object = get_post_type_object( static::SLUG );
 
 		$should_filter_content = (
+			isset( $post->post_status )
+			&&
 			( 'publish' !== $post->post_status )
 			&&
 			current_user_can( $post_type_object->cap->edit_post, $post->ID )

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -719,9 +719,9 @@ class Post_Type {
 		}
 
 		$setting_ids_to_unset = $_REQUEST[ $key_for_settings ];
-		$data = json_decode( $post->post_content );
+		$data = json_decode( $post->post_content, true );
 		foreach ( $setting_ids_to_unset as $setting_id ) {
-			unset( $data->{ $setting_id } );
+			unset( $data[ $setting_id ] );
 		}
 		$content = Customize_Snapshot_Manager::encode_json( $data );
 

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -707,6 +707,8 @@ class Post_Type {
 			&&
 			! empty( $_REQUEST[ $key_for_settings ] )
 			&&
+			is_array( $_REQUEST[ $key_for_settings ] )
+			&&
 			isset( $_REQUEST[ static::SLUG ] )
 			&&
 			wp_verify_nonce( $_REQUEST[ static::SLUG ], static::SLUG . '_settings' )

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -362,7 +362,7 @@ class Post_Type {
 			echo '<li>';
 			echo '<details open>';
 			echo '<summary><code>' . esc_html( $setting_id ) . '</code> ';
-			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" class="snapshot-toggle-setting-removal remove"></a>';
+			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" data-text-restore="' . esc_attr( 'Restore setting', 'customize-snapshots' ) . '" class="snapshot-toggle-setting-removal remove">' . esc_html( 'Remove setting', 'customize-snapshots' ) . '</a>';
 
 			// Show error message when there was a publishing error.
 			if ( isset( $setting_params['publish_error'] ) ) {

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -362,7 +362,7 @@ class Post_Type {
 			echo '<li>';
 			echo '<details open>';
 			echo '<summary><code>' . esc_html( $setting_id ) . '</code> ';
-			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" class="cs-toggle-action remove"></a>';
+			echo '<a href="#" id="' . esc_attr( $setting_id ) . '" class="snapshot-toggle-setting-removal remove"></a>';
 
 			// Show error message when there was a publishing error.
 			if ( isset( $setting_params['publish_error'] ) ) {


### PR DESCRIPTION
**Request For Code Review**

Hi @westonruter,
Could you please review this pull request for Issue #17?
- [73c5b28](https://github.com/xwp/wp-customize-snapshots/commit/73c5b28201f8f951f8c3e938405486cfb6f9a40e) : [Create link](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-36a80da8dbba0bdbe840617270bb1182R365) `'Remove setting'`, which toggles to `'Restore setting'` [on click](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-19c3ccdc306cf3ee7efd933155ccae35R18).
  It also [sets a hidden input field](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-19c3ccdc306cf3ee7efd933155ccae35R40) for each setting to be removed.
  On saving, these appear in `$_REQUEST[ 'customize_snapshot_remove_settings' ]`.
  Filter post content  [on content_save_pre](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-36a80da8dbba0bdbe840617270bb1182R117) when this is saved.
  If `$_REQUEST` has settings to be removed, [filter them out](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-36a80da8dbba0bdbe840617270bb1182R722).
  Also, add [simple styling](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-96bf05ff71d50822b5e71fea81a765e1R1) of this 'Remove setting' link.
  It [appears red](https://github.com/xwp/wp-customize-snapshots/compare/feature/allow-deleting-settings?expand=1#diff-96bf05ff71d50822b5e71fea81a765e1R4) when it has the text "Remove setting, and blue otherwise.
