### PR TITLE
Ensure that revisions get created when changesets are updated via explicit saves

### DIFF
--- a/js/compat/customize-snapshots.js
+++ b/js/compat/customize-snapshots.js
@@ -391,18 +391,6 @@
 		},
 
 		/**
-		 * Toggles date notification.
-		 *
-		 * @return {void}.
-		 */
-		toggleDateNotification: function showDateNotification() {
-			var snapshot = this;
-			if ( ! _.isEmpty( snapshot.dateNotification ) ) {
-				snapshot.dateNotification.toggle( ! snapshot.isFutureDate() );
-			}
-		},
-
-		/**
 		 * Overrides the autoSaveEditBox method used in api.Snapshots
 		 * because we do not auto save in < 4.7.
 		 *

--- a/js/compat/customize-snapshots.js
+++ b/js/compat/customize-snapshots.js
@@ -348,7 +348,7 @@
 				}
 			} );
 
-			snapshot.editControlSettings.bind( function() {
+			snapshot.editControlSettings.bind( 'change', function() {
 				snapshot.snapshotButton.prop( 'disabled', false );
 				snapshot.updateButtonText();
 			} );
@@ -480,13 +480,11 @@
 		populateSetting: function populateSetting() {
 			var snapshot = this,
 				date = snapshot.getDateFromInputs(),
-				scheduled, isDirtyDate, editControlSettings;
+				scheduled, isDirtyDate;
 
-			editControlSettings = _.extend( {}, snapshot.editControlSettings.get() );
+			snapshot.editControlSettings( 'title' ).set( snapshot.snapshotTitle.val() );
 
 			if ( ! date || ! snapshot.data.currentUserCanPublish ) {
-				editControlSettings.title = snapshot.snapshotTitle.val();
-				snapshot.editControlSettings.set( editControlSettings );
 				return;
 			}
 
@@ -495,11 +493,7 @@
 
 			isDirtyDate = scheduled && snapshot.isFutureDate();
 			snapshot.dirtyScheduleDate.set( isDirtyDate );
-
-			editControlSettings.title = snapshot.snapshotTitle.val();
-			editControlSettings.date = snapshot.formatDate( date );
-
-			snapshot.editControlSettings.set( editControlSettings );
+			snapshot.editControlSettings( 'date' ).set( snapshot.formatDate( date ) );
 
 			snapshot.updateCountdown();
 			snapshot.editContainer.find( '.reset-time' ).toggle( scheduled );

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -565,7 +565,7 @@
 			snapshot.snapshotEditContainerDisplayed.set( false );
 
 			api.state( 'snapshot-saved' ).bind( function( saved ) {
-				if ( saved ) {
+				if ( saved && ! snapshot.dirtyEditControlValues ) {
 					snapshot.updateSnapshotEditControls();
 				}
 			} );
@@ -611,6 +611,7 @@
 				}
 				snapshot.updatePending = true;
 				snapshot.editBoxAutoSaveTriggered = true;
+				snapshot.dirtyEditControlValues = false;
 				snapshot.updateSnapshot( status ).done( function() {
 					snapshot.updatePending = snapshot.dirtyEditControlValues;
 					if ( ! snapshot.updatePending ) {
@@ -621,23 +622,22 @@
 					snapshot.dirtyEditControlValues = false;
 				} ).fail( function() {
 					snapshot.updatePending = false;
+					snapshot.dirtyEditControlValues = true;
 				} );
 			}, delay );
 
 			snapshot.editControlSettings( 'title' ).bind( function() {
+				snapshot.dirtyEditControlValues = true;
 				if ( ! snapshot.updatePending ) {
 					update();
-				} else {
-					snapshot.dirtyEditControlValues = true;
 				}
 			} );
 
 			snapshot.editControlSettings( 'date' ).bind( function() {
 				if ( snapshot.isFutureDate() ) {
+					snapshot.dirtyEditControlValues = true;
 					if ( ! snapshot.updatePending ) {
 						update();
-					} else {
-						snapshot.dirtyEditControlValues = true;
 					}
 				}
 			} );
@@ -656,16 +656,13 @@
 			// @todo Show loader and disable button while auto saving.
 			api.bind( 'changeset-save', function() {
 				if ( isValidChangesetStatus() ) {
-					snapshot.updatePending = true;
 					snapshot.extendPreviewerQuery();
 				}
 			} );
 
 			api.bind( 'changeset-saved', function() {
-				api.state( 'saved' ).set( true ); // Suppress the AYS dialog.
-
-				if ( isValidChangesetStatus() ) {
-					snapshot.updatePending = false;
+				if ( 'auto-draft' === api.state( 'changesetStatus' ).get() ) {
+					api.state( 'saved' ).set( true ); // Suppress the AYS dialog.
 				}
 			});
 		},

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -661,7 +661,7 @@
 			} );
 
 			api.bind( 'changeset-saved', function() {
-				if ( 'auto-draft' === api.state( 'changesetStatus' ).get() ) {
+				if ( 'auto-draft' !== api.state( 'changesetStatus' ).get() ) {
 					api.state( 'saved' ).set( true ); // Suppress the AYS dialog.
 				}
 			});

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -1083,7 +1083,7 @@
 		},
 
 		/**
-		 * Remove 'customize_changeset_status' if its already set.
+		 * Remove 'customize_changeset_status' if its already set; replace with customize_snapshots_create_revision param.
 		 *
 		 * @return {void}
 		 */
@@ -1113,6 +1113,7 @@
 				isSameStatus = api.state( 'changesetStatus' ).get() === originalOptions.data.customize_changeset_status;
 				if ( 'customize_save' === originalOptions.data.action && isSameStatus && options.data ) {
 					options.data = removeParam( options.data, 'customize_changeset_status' );
+					options.data += '&customize_snapshots_create_revision=1';
 				}
 			} );
 		}

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -1109,7 +1109,7 @@
 					return;
 				}
 
-				if ( 'customize_save' === originalOptions.data.action && options.data ) {
+				if ( 'customize_save' === originalOptions.data.action && options.data && originalOptions.data.customize_changeset_status ) {
 					options.data = removeParam( options.data, 'customize_changeset_status' );
 					snapshot.editBoxAutoSaveTriggered = false;
 				}

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -469,6 +469,7 @@
 				snapshot.editContainer.hide().appendTo( $( '#customize-header-actions' ) );
 				snapshot.dateNotification = snapshot.editContainer.find( '.snapshot-future-date-notification' );
 				snapshot.countdown = snapshot.editContainer.find( '.snapshot-scheduled-countdown' );
+				snapshot.dateControl = snapshot.editContainer.find( '.snapshot-control-date' );
 
 				if ( snapshot.data.currentUserCanPublish ) {
 
@@ -500,6 +501,9 @@
 
 			// Set up toggling of the schedule container.
 			snapshot.snapshotEditContainerDisplayed.bind( function( isDisplayed ) {
+
+				snapshot.dateControl.toggle( 'future' === snapshot.statusButton.value.get() );
+
 				if ( isDisplayed ) {
 					snapshot.editContainer.stop().slideDown( 'fast' ).attr( 'aria-expanded', 'true' );
 					snapshot.snapshotExpandButton.attr( 'aria-pressed', 'true' );

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -146,7 +146,7 @@
 		 */
 		sendUpdateSnapshotRequest: function sendUpdateSnapshotRequest( options ) {
 			var snapshot = this,
-				request, data, publishStatus;
+				request, data, isPublishStatus;
 
 			data = _.extend(
 				{
@@ -161,7 +161,7 @@
 
 			request = api.previewer.save( data );
 
-			publishStatus = 'publish' === data.status;
+			isPublishStatus = 'publish' === data.status;
 
 			request.always( function( response ) {
 				snapshot.spinner.removeClass( 'is-active' );
@@ -196,10 +196,10 @@
 
 				api.state( 'snapshot-exists' ).set( true );
 
-				snapshot.statusButton.disableSelect.set( publishStatus );
+				snapshot.statusButton.disableSelect.set( isPublishStatus );
 				snapshot.statusButton.disbleButton.set( true );
-				snapshot.snapshotExpandButton.toggle( ! publishStatus );
-				snapshot.previewLink.toggle( ! publishStatus );
+				snapshot.snapshotExpandButton.toggle( ! isPublishStatus );
+				snapshot.previewLink.toggle( ! isPublishStatus );
 
 				snapshot.statusButton.updateButtonText( 'alt-text' );
 
@@ -507,7 +507,9 @@
 					snapshot.editContainer.stop().slideDown( 'fast' ).attr( 'aria-expanded', 'true' );
 					snapshot.snapshotExpandButton.attr( 'aria-pressed', 'true' );
 					snapshot.snapshotExpandButton.prop( 'title', snapshot.data.i18n.collapseSnapshotScheduling );
-					snapshot.toggleDateNotification();
+					if ( ! _.isEmpty( snapshot.dateNotification ) ) {
+						snapshot.dateNotification.toggle( ! snapshot.isFutureDate() );
+					}
 				} else {
 					snapshot.editContainer.stop().slideUp( 'fast' ).attr( 'aria-expanded', 'false' );
 					snapshot.snapshotExpandButton.attr( 'aria-pressed', 'false' );
@@ -516,12 +518,17 @@
 			} );
 
 			snapshot.editControlSettings( 'date' ).bind( function() {
-				snapshot.toggleDateNotification();
+				if ( ! _.isEmpty( snapshot.dateNotification ) ) {
+					snapshot.dateNotification.toggle( ! snapshot.isFutureDate() );
+
+					if ( 'future' === snapshot.statusButton.value.get() ) {
+						snapshot.statusButton.disbleButton.set( ! snapshot.isFutureDate() );
+					}
+				}
 			} );
 
 			// Toggle schedule container when clicking the button.
-			snapshot.snapshotExpandButton.on( 'click', function( event ) {
-				event.preventDefault();
+			snapshot.snapshotExpandButton.on( 'click', function() {
 				snapshot.snapshotEditContainerDisplayed.set( ! snapshot.snapshotEditContainerDisplayed.get() );
 			} );
 
@@ -651,22 +658,6 @@
 					snapshot.updatePending = false;
 				}
 			});
-		},
-
-		/**
-		 * Toggles date notification.
-		 *
-		 * @return {void}.
-		 */
-		toggleDateNotification: function showDateNotification() {
-			var snapshot = this;
-			if ( ! _.isEmpty( snapshot.dateNotification ) ) {
-				snapshot.dateNotification.toggle( ! snapshot.isFutureDate() );
-
-				if ( 'future' === snapshot.statusButton.value.get() ) {
-					snapshot.statusButton.disbleButton.set( ! snapshot.isFutureDate() );
-				}
-			}
 		},
 
 		/**

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -509,7 +509,9 @@
 			// Set up toggling of the schedule container.
 			snapshot.snapshotEditContainerDisplayed.bind( function( isDisplayed ) {
 
-				snapshot.dateControl.toggle( 'future' === snapshot.statusButton.value.get() );
+				if ( snapshot.statusButton ) {
+					snapshot.dateControl.toggle( 'future' === snapshot.statusButton.value.get() );
+				}
 
 				if ( isDisplayed ) {
 					snapshot.editContainer.stop().slideDown( 'fast' ).attr( 'aria-expanded', 'true' );

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -104,7 +104,6 @@ class Customize_Snapshot_Manager {
 		add_action( 'admin_bar_menu', array( $this, 'remove_all_non_snapshot_admin_bar_links' ), 100000 );
 		add_action( 'wp_before_admin_bar_render', array( $this, 'print_admin_bar_styles' ) );
 		add_filter( 'removable_query_args', array( $this, 'filter_removable_query_args' ) );
-		add_filter( 'wp_save_post_revision_post_has_changed', array( $this, '_filter_revision_post_has_changed' ), 20, 3 );
 		add_action( 'save_post_customize_changeset', array( $this, 'create_initial_changeset_revision' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'prepare_snapshot_post_content_for_publish' ) );
 	}
@@ -355,24 +354,6 @@ class Customize_Snapshot_Manager {
 		if ( 0 === count( wp_get_post_revisions( $post_id ) ) ) {
 			wp_save_post_revision( $post_id );
 		}
-	}
-
-	/**
-	 * When a customize_save Ajax action is being made, ensure a revision is allowed if customize_snapshots_create_revision query param is present.
-	 *
-	 * @see \WP_Customize_Manager::_filter_revision_post_has_changed()
-	 *
-	 * @param bool     $post_has_changed Whether the post has changed.
-	 * @param \WP_Post $last_revision    The last revision post object.
-	 * @param \WP_Post $post             The post object.
-	 * @return bool Whether a revision should be made.
-	 */
-	public function _filter_revision_post_has_changed( $post_has_changed, $last_revision, $post ) {
-		unset( $last_revision );
-		if ( 'customize_changeset' === $post->post_type && ! empty( $_POST['customize_snapshots_create_revision'] ) ) {
-			$post_has_changed = true;
-		}
-		return $post_has_changed;
 	}
 
 	/**

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -741,15 +741,15 @@ class Customize_Snapshot_Manager {
 				</div>
 
 				<ul class="snapshot-controls">
-					<li class="snapshot-control">
-						<label for="snapshot-title" class="customize-control-title snapshot-control-title">
+					<li class="snapshot-control snapshot-control-title">
+						<label for="snapshot-title" class="customize-control-title">
 							<?php esc_html_e( 'Title', 'customize-snapshots' ); ?>
 						</label>
 						<input id="snapshot-title" type="text" value="{{data.title}}">
 					</li>
 					<# if ( data.currentUserCanPublish ) { #>
-						<li class="snapshot-control">
-							<label for="snapshot-date-month" class="customize-control-title snapshot-control-title">
+						<li class="snapshot-control snapshot-control-date">
+							<label for="snapshot-date-month" class="customize-control-title">
 								<?php esc_html_e( 'Scheduling', 'customize-snapshots' ); ?>
 								<span class="reset-time">(<a href="#" title="<?php esc_attr_e( 'Reset scheduled date to original or current date', 'customize-snapshots' ); ?>"><?php esc_html_e( 'Reset', 'customize-snapshots' ) ?></a>)</span>
 							</label>

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -104,6 +104,8 @@ class Customize_Snapshot_Manager {
 		add_action( 'admin_bar_menu', array( $this, 'remove_all_non_snapshot_admin_bar_links' ), 100000 );
 		add_action( 'wp_before_admin_bar_render', array( $this, 'print_admin_bar_styles' ) );
 		add_filter( 'removable_query_args', array( $this, 'filter_removable_query_args' ) );
+		add_filter( 'wp_save_post_revision_post_has_changed', array( $this, '_filter_revision_post_has_changed' ), 20, 3 );
+		add_filter( 'save_post_customize_changeset', array( $this, 'create_initial_changeset_revision' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'prepare_snapshot_post_content_for_publish' ) );
 	}
 
@@ -340,6 +342,37 @@ class Customize_Snapshot_Manager {
 	 */
 	public function snapshot() {
 		return $this->snapshot;
+	}
+
+	/**
+	 * Create initial changeset revision.
+	 *
+	 * This should be removed once #30854 is resolved.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/30854
+	 */
+	public function create_initial_changeset_revision( $post_id ) {
+		if ( 0 === count( wp_get_post_revisions( $post_id ) ) ) {
+			wp_save_post_revision( $post_id );
+		}
+	}
+
+	/**
+	 * When a customize_save Ajax action is being made, ensure a revision is allowed if customize_snapshots_create_revision query param is present.
+	 *
+	 * @see \WP_Customize_Manager::_filter_revision_post_has_changed()
+	 *
+	 * @param bool     $post_has_changed Whether the post has changed.
+	 * @param \WP_Post $last_revision    The last revision post object.
+	 * @param \WP_Post $post             The post object.
+	 * @return bool Whether a revision should be made.
+	 */
+	public function _filter_revision_post_has_changed( $post_has_changed, $last_revision, $post ) {
+		unset( $last_revision );
+		if ( 'customize_changeset' === $post->post_type && ! empty( $_POST['customize_snapshots_create_revision'] ) ) {
+			$post_has_changed = true;
+		}
+		return $post_has_changed;
 	}
 
 	/**

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -105,7 +105,7 @@ class Customize_Snapshot_Manager {
 		add_action( 'wp_before_admin_bar_render', array( $this, 'print_admin_bar_styles' ) );
 		add_filter( 'removable_query_args', array( $this, 'filter_removable_query_args' ) );
 		add_filter( 'wp_save_post_revision_post_has_changed', array( $this, '_filter_revision_post_has_changed' ), 20, 3 );
-		add_filter( 'save_post_customize_changeset', array( $this, 'create_initial_changeset_revision' ) );
+		add_action( 'save_post_customize_changeset', array( $this, 'create_initial_changeset_revision' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'prepare_snapshot_post_content_for_publish' ) );
 	}
 


### PR DESCRIPTION
Found a bug with 0.6.0-rc1 whereby revisions were no longer being made as expected when explicitly clicking the Save Draft button in the UI. The opt-in for creating a revision in core is currently indicated by whether or not a `customize_changeset_status` param is present. This is not ideal, but since the param is getting stripped by Customize Snapshots if the status is the same as the current status, I added a workaround for this to explicitly indicate the need to create a revision via another channel. There is probably a better solution for this, not at least to allow a `save_revision` to be passed when calling `wp.customize.previewer.save()`. 

See: https://github.com/WordPress/wordpress-develop/blob/8900e2466e3a01c9c228ac31784aa70e8dcf3137/src/wp-includes/class-wp-customize-manager.php#L2279