### PR TITLE
Improve migration

### DIFF
--- a/js/customize-migrate.js
+++ b/js/customize-migrate.js
@@ -3,7 +3,7 @@
 	'use strict';
 	var component = {
 		doingAjax: false,
-		postMigrationCount: 20
+		postMigrationCount: 5
 	};
 
 	/**

--- a/php/class-customize-snapshot-command.php
+++ b/php/class-customize-snapshot-command.php
@@ -44,11 +44,13 @@ class Customize_Snapshot_Command {
 		}
 		$dry_mode = isset( $assoc_args['dry-run'] );
 		if ( ! $dry_mode ) {
+			wp_suspend_cache_addition( true );
 			$post_count = $migrate_obj->changeset_migrate();
 			\WP_CLI::success( $post_count . ' ' . __( 'posts migrated.', 'customize-snapshots' ) );
 		} else {
-			$ids = $migrate_obj->changeset_migrate( - 1, true );
-			\WP_CLI::success( count( $ids ) . ' ' . __( 'posts migrated:', 'customize-snapshots' ) . ' ' . implode( ',', $ids ) );
+			$ids = $migrate_obj->changeset_migrate( -1, true );
+			\WP_CLI::success( __( 'Posts migrated:', 'customize-snapshots' ) . ' ' . implode( ',', $ids ) );
+			\WP_CLI::success( 'Total ' . count( $ids ) . ' ' . __( 'posts migrated.', 'customize-snapshots' ) );
 		}
 	}
 }


### PR DESCRIPTION
change wp_update_post to update via $wpdb to skip extra hooks,
change ajax limit to 5 to avoid large snapshot migration timeouts,
improve migration verbosity.