### PR TITLE
Prevent removal of customize_changeset_status if the status are not same

### DIFF
--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -1085,7 +1085,7 @@
 		 * @return {void}
 		 */
 		prefilterAjax: function prefilterAjax() {
-			var snapshot = this, removeParam;
+			var snapshot = this, removeParam, isSameStatus;
 
 			if ( ! api.state.has( 'changesetStatus' ) ) {
 				return;
@@ -1108,7 +1108,8 @@
 					return;
 				}
 
-				if ( 'customize_save' === originalOptions.data.action && options.data && originalOptions.data.customize_changeset_status ) {
+				isSameStatus = api.state( 'changesetStatus' ).get() === originalOptions.data.customize_changeset_status;
+				if ( 'customize_save' === originalOptions.data.action && options.data && originalOptions.data.customize_changeset_status && isSameStatus ) {
 					options.data = removeParam( options.data, 'customize_changeset_status' );
 					snapshot.editBoxAutoSaveTriggered = false;
 				}


### PR DESCRIPTION
In https://github.com/xwp/wp-customize-snapshots/pull/111 we had removed `isSameStatus` check before removing the `customize_changeset_status` because of which empty status was being sent when you add or change to a new status and hence throwing error for the first time in schedule. Fixed