### PR TITLE
Uglify and run jshint on JS files in js/compat directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,8 +15,8 @@ module.exports = function( grunt ) {
 			},
 			all: [
 				'Gruntfile.js',
-				'js/*.js',
-				'!js/*.min.js'
+				'js/**/*.js',
+				'!js/**/*.min.js'
 			]
 		},
 
@@ -30,7 +30,7 @@ module.exports = function( grunt ) {
 					expand: true,
 					cwd: 'js/',
 					src: [
-						'**.js',
+						'**/*.js',
 						'!**.min.js'
 					],
 					dest: 'js/',


### PR DESCRIPTION
The minified JS files in the `compat` directory are 404'ing on a 4.6 install.