### PR TITLE
Restore changeset preview session resuming

### DIFF
--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -1,0 +1,102 @@
+/* global jQuery, confirm */
+/* exported CustomizeSnapshotsFrontend */
+/* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [-1,0,1] } ] */
+/* eslint-disable no-alert */
+
+var CustomizeSnapshotsFrontend = ( function( $ ) {
+	'use strict';
+
+	var component = {
+		data: {
+			uuid: '',
+			l10n: {
+				restoreSessionPrompt: ''
+			}
+		}
+	};
+
+	/**
+	 * Init.
+	 *
+	 * @param {object} args Args.
+	 * @param {string} args.uuid UUID.
+	 * @returns {void}
+	 */
+	component.init = function init( args ) {
+		_.extend( component.data, args );
+
+		component.hasSessionStorage = 'undefined' !== typeof sessionStorage;
+
+		component.keepSessionAlive();
+		component.rememberSessionSnapshot();
+		component.handleExitSnapshotSessionLink();
+	};
+
+	/**
+	 * Prompt to restore session.
+	 *
+	 * @returns {void}
+	 */
+	component.keepSessionAlive = function keepSessionAlive() {
+		var currentSnapshotUuid, urlParser, adminBarItem;
+		if ( ! component.hasSessionStorage ) {
+			return;
+		}
+		currentSnapshotUuid = sessionStorage.getItem( 'customize_changeset_uuid' );
+		if ( ! currentSnapshotUuid || component.data.uuid ) {
+			return;
+		}
+
+		urlParser = document.createElement( 'a' );
+		urlParser.href = location.href;
+		if ( urlParser.search.length > 1 ) {
+			urlParser.search += '&';
+		}
+		urlParser.search += 'customize_changeset_uuid=' + encodeURIComponent( sessionStorage.getItem( 'customize_changeset_uuid' ) );
+
+		$( function() {
+			adminBarItem = $( '#wp-admin-bar-resume-customize-snapshot' );
+			if ( adminBarItem.length ) {
+				adminBarItem.find( '> a' ).prop( 'href', urlParser.href );
+				adminBarItem.show();
+			} else if ( confirm( component.data.l10n.restoreSessionPrompt ) ) {
+				location.replace( urlParser.href );
+			} else {
+				sessionStorage.removeItem( 'customize_changeset_uuid' );
+			}
+		} );
+	};
+
+	/**
+	 * Remember the session's snapshot.
+	 *
+	 * Persist the snapshot UUID in session storage so that we can prompt to restore the snapshot query param if inadvertently dropped.
+	 *
+	 * @returns {void}
+	 */
+	component.rememberSessionSnapshot = function rememberSessionSnapshot() {
+		if ( ! component.hasSessionStorage || ! component.data.uuid ) {
+			return;
+		}
+		sessionStorage.setItem( 'customize_changeset_uuid', component.data.uuid );
+	};
+
+	/**
+	 * Handle electing to exit from the snapshot session.
+	 *
+	 * @returns {void}
+	 */
+	component.handleExitSnapshotSessionLink = function handleExitSnapshotSessionLink() {
+		$( function() {
+			if ( ! component.hasSessionStorage ) {
+				return;
+			}
+			$( '#wpadminbar' ).on( 'click', '#wp-admin-bar-exit-customize-snapshot', function() {
+				sessionStorage.removeItem( 'customize_changeset_uuid' );
+			} );
+		} );
+	};
+
+	return component;
+} )( jQuery );
+

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -300,14 +300,14 @@ class Customize_Snapshot_Manager {
 				'submit' => __( 'Submit', 'customize-snapshots' ),
 				'submitted' => __( 'Submitted', 'customize-snapshots' ),
 				'permsMsg' => array(
-					'save' => __( 'You do not have permission to publish changes, but you can create a snapshot by clicking the "Save" button.', 'customize-snapshots' ),
-					'update' => __( 'You do not have permission to publish changes, but you can modify this snapshot by clicking the "Update" button.', 'customize-snapshots' ),
+					'save' => __( 'You do not have permission to publish changes, but you can create a changeset by clicking the "Save" button.', 'customize-snapshots' ),
+					'update' => __( 'You do not have permission to publish changes, but you can modify this changeset by clicking the "Update" button.', 'customize-snapshots' ),
 				),
 				'aysMsg' => __( 'Changes that you made may not be saved.', 'customize-snapshots' ),
-				'errorMsg' => __( 'The snapshot could not be saved.', 'customize-snapshots' ),
+				'errorMsg' => __( 'The changeset could not be saved.', 'customize-snapshots' ),
 				'errorTitle' => __( 'Error', 'customize-snapshots' ),
-				'collapseSnapshotScheduling' => __( 'Collapse snapshot scheduling', 'customize-snapshots' ),
-				'expandSnapshotScheduling' => __( 'Expand snapshot scheduling', 'customize-snapshots' ),
+				'collapseSnapshotScheduling' => __( 'Collapse changeset scheduling', 'customize-snapshots' ),
+				'expandSnapshotScheduling' => __( 'Expand changeset scheduling', 'customize-snapshots' ),
 			),
 		) );
 
@@ -607,7 +607,7 @@ class Customize_Snapshot_Manager {
 	public function add_resume_snapshot_link( $wp_admin_bar ) {
 		$wp_admin_bar->add_menu( array(
 			'id' => 'resume-customize-snapshot',
-			'title' => __( 'Resume Snapshot Preview', 'customize-snapshots' ),
+			'title' => __( 'Resume Changeset Preview', 'customize-snapshots' ),
 			'href' => '#',
 			'meta' => array(
 				'class' => 'ab-item ab-customize-snapshots-item',
@@ -616,7 +616,7 @@ class Customize_Snapshot_Manager {
 	}
 
 	/**
-	 * Adds a "Snapshot in Dashboard" link to the Toolbar when in Snapshot mode.
+	 * Adds a "Inspect Changeset" link to the Toolbar when previewing a changeset.
 	 *
 	 * @param \WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
 	 */
@@ -630,7 +630,7 @@ class Customize_Snapshot_Manager {
 		}
 		$wp_admin_bar->add_menu( array(
 			'id' => 'inspect-customize-snapshot',
-			'title' => __( 'Inspect Snapshot', 'customize-snapshots' ),
+			'title' => __( 'Inspect Changeset', 'customize-snapshots' ),
 			'href' => $this->snapshot->get_edit_link( $post ),
 			'meta' => array(
 				'class' => 'ab-item ab-customize-snapshots-item',
@@ -639,7 +639,7 @@ class Customize_Snapshot_Manager {
 	}
 
 	/**
-	 * Adds an "Exit Snapshot" link to the Toolbar when in Snapshot mode.
+	 * Adds an "Exit Changeset Preview" link to the Toolbar when previewing a changeset.
 	 *
 	 * @param \WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
 	 */
@@ -649,7 +649,7 @@ class Customize_Snapshot_Manager {
 		}
 		$wp_admin_bar->add_menu( array(
 			'id' => 'exit-customize-snapshot',
-			'title' => __( 'Exit Snapshot Preview', 'customize-snapshots' ),
+			'title' => __( 'Exit Changeset Preview', 'customize-snapshots' ),
 			'href' => remove_query_arg( $this->get_front_uuid_param() ),
 			'meta' => array(
 				'class' => 'ab-item ab-customize-snapshots-item',
@@ -750,7 +750,7 @@ class Customize_Snapshot_Manager {
 			<# _.defaults( data, <?php echo wp_json_encode( $data ); ?> ); #>
 
 			<div id="snapshot-status-button-wrapper">
-				<label class="screen-reader-text" for="snapshot-status-button"><?php esc_attr_e( 'Snapshot Status', 'customize-snapshots' ); ?></label>
+				<label class="screen-reader-text" for="snapshot-status-button"><?php esc_attr_e( 'Changeset Status', 'customize-snapshots' ); ?></label>
 				<select id="snapshot-status-button">
 					<# _.each( data.choices, function( buttonText, status ) { #>
 							<option value="{{ status }}" data-alt-text="{{ buttonText.alt_text }}"
@@ -782,9 +782,9 @@ class Customize_Snapshot_Manager {
 			<div id="customize-snapshot">
 				<div class="snapshot-schedule-title">
 					<h3>
-						<?php esc_html_e( 'Edit Snapshot', 'customize-snapshots' ); ?>
+						<?php esc_html_e( 'Edit Changeset', 'customize-snapshots' ); ?>
 					</h3>
-					<?php $edit_snapshot_text = __( 'Edit Snapshot', 'customize-snapshots' ); ?>
+					<?php $edit_snapshot_text = __( 'Edit Changeset', 'customize-snapshots' ); ?>
 					<a href="{{ data.editLink }}" class="dashicons dashicons-external snapshot-edit-link" target="_blank" title="<?php echo esc_attr( $edit_snapshot_text ); ?>" aria-expanded="false"><span class="screen-reader-text"><?php echo esc_html( $edit_snapshot_text ); ?></span></a>
 				</div>
 
@@ -879,19 +879,19 @@ class Customize_Snapshot_Manager {
 			<# } else if ( data.remainingTime < 60 * 60 ) { #>
 			<?php
 			/* translators: %s is a placeholder for the Underscore template var */
-			echo sprintf( esc_html__( 'This snapshot is scheduled for publishing in about %s minutes.', 'customize-snapshots' ), '{{ Math.ceil( data.remainingTime / 60 ) }}' );
+			echo sprintf( esc_html__( 'This changeset is scheduled for publishing in about %s minutes.', 'customize-snapshots' ), '{{ Math.ceil( data.remainingTime / 60 ) }}' );
 			?>
 
 			<# } else if ( data.remainingTime < 24 * 60 * 60 ) { #>
 			<?php
 			/* translators: %s is a placeholder for the Underscore template var */
-			echo sprintf( esc_html__( 'This snapshot is scheduled for publishing in about %s hours.', 'customize-snapshots' ), '{{ Math.round( data.remainingTime / 60 / 60 * 10 ) / 10 }}' );
+			echo sprintf( esc_html__( 'This changeset is scheduled for publishing in about %s hours.', 'customize-snapshots' ), '{{ Math.round( data.remainingTime / 60 / 60 * 10 ) / 10 }}' );
 			?>
 
 			<# } else { #>
 				<?php
 				/* translators: %s is a placeholder for the Underscore template var */
-				echo sprintf( esc_html__( 'This snapshot is scheduled for publishing in about %s days.', 'customize-snapshots' ), '{{ Math.round( data.remainingTime / 60 / 60 / 24 * 10 ) / 10 }}' );
+				echo sprintf( esc_html__( 'This changeset is scheduled for publishing in about %s days.', 'customize-snapshots' ), '{{ Math.round( data.remainingTime / 60 / 60 / 24 * 10 ) / 10 }}' );
 				?>
 
 				<# } #>

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -97,6 +97,7 @@ class Customize_Snapshot_Manager {
 		add_action( 'init', array( $this->post_type, 'init' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_controls_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
 
 		add_action( 'customize_controls_init', array( $this, 'add_snapshot_uuid_to_return_url' ) );
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'render_templates' ) );
@@ -340,6 +341,30 @@ class Customize_Snapshot_Manager {
 				'after'
 			);
 		}
+	}
+
+	/**
+	 * Enqueue Customizer frontend scripts.
+	 */
+	public function enqueue_frontend_scripts() {
+		if ( ! current_user_can( 'customize' ) ) {
+			return;
+		}
+		$handle = 'customize-snapshots-frontend';
+		wp_enqueue_script( $handle );
+
+		$exports = array(
+			'uuid' => $this->snapshot ? $this->snapshot->uuid() : null,
+			'home_url' => wp_parse_url( home_url( '/' ) ),
+			'l10n' => array(
+				'restoreSessionPrompt' => __( 'It seems you may have inadvertently navigated away from previewing a customized state. Would you like to restore the changeset context?', 'customize-snapshots' ),
+			),
+		);
+		wp_add_inline_script(
+			$handle,
+			sprintf( 'CustomizeSnapshotsFrontend.init( %s )', wp_json_encode( $exports ) ),
+			'after'
+		);
 	}
 
 	/**

--- a/php/class-migrate.php
+++ b/php/class-migrate.php
@@ -94,7 +94,7 @@ class Migrate {
 			<p>
 			<?php
 			esc_html_e( 'Existing Snapshots need to be migrated to Changesets, which was added to core in WordPress 4.7.', 'customize-snapshots' );
-			printf( ' %s <a id="customize-snapshot-migration" data-nonce="' . esc_attr( wp_create_nonce( 'customize-snapshot-migration' ) ) . '" href="javascript:void(0)" data-migration-success="%s">%s</a> %s <span class="spinner customize-snapshot-spinner"></span>', esc_html__( 'Click', 'customize-snapshots' ), esc_html__( 'Customize snapshot migration complete!', 'customize-snapshots' ), esc_html__( 'here', 'customize-snapshots' ), esc_html__( 'to start migration.', 'customize-snapshots' ) );
+			printf( ' %s <a id="customize-snapshot-migration" data-nonce="' . esc_attr( wp_create_nonce( 'customize-snapshot-migration' ) ) . '" href="javascript:void(0)" data-migration-success="%s">%s</a> %s <span class="spinner customize-snapshot-spinner"></span>', esc_html__( 'Click', 'customize-snapshots' ), esc_html__( 'Migration of snapshots to changesets complete!', 'customize-snapshots' ), esc_html__( 'here', 'customize-snapshots' ), esc_html__( 'to start migration.', 'customize-snapshots' ) );
 			?>
 			</p>
 		</div>
@@ -133,7 +133,7 @@ class Migrate {
 
 		if ( $is_doing_cli ) {
 			/* translators: %s: post count.*/
-			\WP_CLI::log( sprintf( __( 'Migrating %s Snapshots into Changeset', 'customize-snapshots' ), count( $query->posts ) ) );
+			\WP_CLI::log( sprintf( __( 'Migrating %s Snapshots into Changesets', 'customize-snapshots' ), count( $query->posts ) ) );
 		}
 
 		if ( ! empty( $query->posts ) ) {

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -123,6 +123,11 @@ class Plugin extends Plugin_Base {
 			$src = $this->dir_url . 'js/customize-migrate' . $min . '.js';
 			$deps = array( 'jquery', 'wp-util' );
 			$wp_scripts->add( $handle, $src, $deps );
+
+			$handle = 'customize-snapshots-frontend';
+			$src = $this->dir_url . 'js/customize-snapshots-frontend' . $min . '.js';
+			$deps = array( 'jquery', 'underscore' );
+			$wp_scripts->add( $handle, $src, $deps );
 		}
 
 		$handle = 'customize-snapshots-admin';


### PR DESCRIPTION
I found that the changeset session restoration feature didn't make it as part of the split out of the old compat code.

Remember this feature allowed you to be in changeset frontend preview:

![image](https://user-images.githubusercontent.com/134745/28607375-84a67042-7190-11e7-82d9-bbd4b7674f0e.png)

And then if you left the frontend preview by a means other than the Exit link, the next time you were on the frontend you'd see the admin bar with a resume link:

![image](https://user-images.githubusercontent.com/134745/28607370-7abb3e00-7190-11e7-87d2-382f5f034380.png)

I also replaced more instances of “snapshots” with “changesets” in the non-compat code.
