### PR TITLE
Remove markup from post list table excerpts since now escaped

### DIFF
--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -283,13 +283,13 @@ class Post_Type {
 	public function filter_snapshot_excerpt( $excerpt, $post = null ) {
 		$post = get_post( $post );
 		if ( static::SLUG === $post->post_type ) {
-			$excerpt = '<ol>';
+			$settings = array();
 			foreach ( $this->get_post_content( $post ) as $setting_id => $setting_params ) {
 				if ( ! isset( $setting_params['dirty'] ) || true === $setting_params['dirty'] ) {
-					$excerpt .= sprintf( '<li><code>%s</code></li>', esc_attr( $setting_id ) );
+					$settings[] = $setting_id;
 				}
 			}
-			$excerpt .= '</ol>';
+			$excerpt = join( ', ', array_map( 'esc_html', $settings ) );
 		}
 		return $excerpt;
 	}


### PR DESCRIPTION
Previously in the “excerpt view” of the post list table, we could see a list of all the settings in the changeset at a glance:

![image](https://user-images.githubusercontent.com/134745/28608010-6dd77a84-7193-11e7-8d6c-38eb0a1bd5b4.png)

However, as of https://github.com/WordPress/wordpress-develop/commit/a96089e8e6ea09069869f45aa0d3e43c3e6427ce this is now broken and it looks like:

<img width="1168" alt="screen shot 2017-07-25 at 23 39 30" src="https://user-images.githubusercontent.com/134745/28608033-8607e274-7193-11e7-907b-a3a8e286bd9b.png">

So since the excerpt is now HTML-escaped, we have to just output a list of setting IDs in a comma-separated list:

<img width="1069" alt="screen shot 2017-07-25 at 23 39 53" src="https://user-images.githubusercontent.com/134745/28608052-9fdf5b96-7193-11e7-8629-d72cc3d885b9.png">
