### PR TITLE
Update Travis to use the precise distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 
 notifications:
   email:


### PR DESCRIPTION
This will fix the 5.3 builds. See https://github.com/xwp/wp-dev-lib/pull/249