### PR TITLE
Prevent changeset session remembrance when browsing in preview iframe

### DIFF
--- a/js/customize-snapshots-frontend.js
+++ b/js/customize-snapshots-frontend.js
@@ -75,7 +75,8 @@ var CustomizeSnapshotsFrontend = ( function( $ ) {
 	 * @returns {void}
 	 */
 	component.rememberSessionSnapshot = function rememberSessionSnapshot() {
-		if ( ! component.hasSessionStorage || ! component.data.uuid ) {
+		var isCustomizerFramePreview = /(^|\?|&)customize_messenger_channel=/.test( location.search );
+		if ( ! component.hasSessionStorage || ! component.data.uuid || isCustomizerFramePreview ) {
 			return;
 		}
 		sessionStorage.setItem( 'customize_changeset_uuid', component.data.uuid );


### PR DESCRIPTION
I was noticing the “Resume Changeset Preview” admin bar link from appearing unexpectedly, even when I never browsed the preview on the frontend. The remembering of the changeset should only be done when previewing a changeset on the frontend, not when previewing a changeset inside the Customizer preview iframe.

It looks like this was missed as part of #145.