### PR TITLE
Add required PHP version go readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Provide a UI for managing Customizer changesets; save changesets as named drafts
 **Tested up to:** 4.8.1  
 **Stable tag:** 0.6.2  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
+**Requires PHP:** 5.3  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customize-snapshots.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-snapshots) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-snapshots/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-snapshots) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-snapshots/dev-status.svg)](https://david-dm.org/xwp/wp-customize-snapshots?type=dev) 
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: xwp, westonruter, valendesigns, utkarshpatel, sayedwp, newscorpau
 Requires at least: 4.6
 Tested up to: 4.8.1
 Stable tag: 0.6.2
+Requires PHP: 5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: customizer, customize, changesets


### PR DESCRIPTION
Fixes #159.

See https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/