### PR TITLE
Add workaround to fix pending status causing infinite loop when user does not have publish capability

### DIFF
--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -1,6 +1,7 @@
 /* global wp, jQuery */
 /* eslint consistent-this: [ "error", "snapshot", "control" ] */
 /* eslint no-magic-numbers: ["error", { "ignore": [0, 1] }] */
+/* eslint max-nested-callbacks: [ "error", 4 ] */
 
 (function( api, $ ) {
 	'use strict';
@@ -53,6 +54,15 @@
 					snapshot.addPendingToStatusControl();
 					snapshot.addTitleControl( section );
 					snapshot.addInspectChangesetControl( section );
+
+					/**
+					 * This is not ideal but is just a workaround to fix https://core.trac.wordpress.org/ticket/42686 for 4.9.0.
+					 */
+					section.expanded.bind( function( expanded ) {
+						if ( snapshot.data.addWorkaroundFor42686 && expanded ) {
+							api.settings.changeset.currentUserCanPublish = true;
+						}
+					} );
 				} );
 
 				// For backward compat.

--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -56,7 +56,7 @@
 					snapshot.addInspectChangesetControl( section );
 
 					/**
-					 * This is not ideal but is just a workaround to fix https://core.trac.wordpress.org/ticket/42686 for 4.9.0.
+					 * This is not ideal but is just a workaround to fix https://core.trac.wordpress.org/ticket/42686 for 4.9 and 4.9.1.
 					 */
 					section.expanded.bind( function( expanded ) {
 						if ( snapshot.data.addWorkaroundFor42686 && expanded ) {

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -202,6 +202,7 @@ class Customize_Snapshot_Manager {
 		// Script data array.
 		$exports = apply_filters( 'customize_snapshots_export_data', array(
 			'inspectLink' => isset( $edit_link ) ? $edit_link : '',
+			'addWorkaroundFor42686' => version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '==' ),
 			'title' => isset( $post->post_title ) ? $post->post_title : '',
 			'previewingTheme' => isset( $preview_url_query_vars['theme'] ) ? $preview_url_query_vars['theme'] : '',
 			'i18n' => array(

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -190,6 +190,7 @@ class Customize_Snapshot_Manager {
 		$post = null;
 		$preview_url_query_vars = array();
 		$post_id = $this->get_customize_manager()->changeset_post_id();
+		$wp_version = strtok( get_bloginfo( 'version' ), '-' );
 
 		if ( $post_id ) {
 			$post = get_post( $post_id );
@@ -202,7 +203,7 @@ class Customize_Snapshot_Manager {
 		// Script data array.
 		$exports = apply_filters( 'customize_snapshots_export_data', array(
 			'inspectLink' => isset( $edit_link ) ? $edit_link : '',
-			'addWorkaroundFor42686' => version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '==' ),
+			'addWorkaroundFor42686' => version_compare( $wp_version, '4.9', '==' ) || version_compare( $wp_version, '4.9.1', '==' ),
 			'title' => isset( $post->post_title ) ? $post->post_title : '',
 			'previewingTheme' => isset( $preview_url_query_vars['theme'] ) ? $preview_url_query_vars['theme'] : '',
 			'i18n' => array(


### PR DESCRIPTION
Workaround for https://github.com/xwp/wp-customize-snapshots/issues/167

Fixes #167.