### PR TITLE
Update WP version number required for workaround added in #171 for #167

### DIFF
--- a/js/customize-snapshots.js
+++ b/js/customize-snapshots.js
@@ -78,7 +78,7 @@
 					snapshot.addInspectChangesetControl( section );
 
 					/**
-					 * This is not ideal but is just a workaround to fix https://core.trac.wordpress.org/ticket/42686 for 4.9 and 4.9.1.
+					 * This is not ideal but is just a workaround to fix https://core.trac.wordpress.org/ticket/42686 for 4.9, 4.9.1, and 4.9.2.
 					 */
 					section.expanded.bind( function( expanded ) {
 						if ( snapshot.data.addWorkaroundFor42686 && expanded ) {

--- a/php/class-customize-snapshot-manager.php
+++ b/php/class-customize-snapshot-manager.php
@@ -214,7 +214,7 @@ class Customize_Snapshot_Manager {
 		// Script data array.
 		$exports = apply_filters( 'customize_snapshots_export_data', array(
 			'inspectLink' => isset( $edit_link ) ? $edit_link : '',
-			'addWorkaroundFor42686' => version_compare( $wp_version, '4.9', '==' ) || version_compare( $wp_version, '4.9.1', '==' ),
+			'addWorkaroundFor42686' => version_compare( $wp_version, '4.9', '>=' ) && version_compare( $wp_version, '4.9.2', '<=' ),
 			'title' => isset( $post->post_title ) ? $post->post_title : '',
 			'previewingTheme' => isset( $preview_url_query_vars['theme'] ) ? $preview_url_query_vars['theme'] : '',
 			'i18n' => array(


### PR DESCRIPTION
See commit in 4.9 branch which will be part of 4.9.3: https://core.trac.wordpress.org/changeset/42544

Amends #171.
